### PR TITLE
Fix Pack 001 APPEND

### DIFF
--- a/so/bj.c
+++ b/so/bj.c
@@ -1,6 +1,6 @@
 #include "bbs.h"
 #include "gamef.c"
-#define SWAP(x, y) do {int temp=(x);(x)=(y);(y)=temp;} while (0)
+#define SWAP(x, y) do {int temp=(x); (x)=(y); (y)=temp;} while (0)
 
 /* ¶Â³Ç§J¹CÀ¸ */
 

--- a/so/mine.c
+++ b/so/mine.c
@@ -42,13 +42,14 @@ enum {  MAP_MAXY = 20,
 static int MAP_Y = MAP_MAXY, MAP_X = MAP_MAXX;
 static int TotalMines = 0, TaggedMines = 0, currx = 0, curry = 0;
 static char MineMap[ MAP_MAXY+2 ][ MAP_MAXX+2 ];
-extern int cur_col;
 int fasttime[4];
 
 void clrtokol(void)
 {
     int n;
-    for (n = cur_col;n < 17;n++)
+    int y, x;
+    getyx(&y, &x);
+    for (n = x;n < 17;n++)
         outc(' ');
 }
 

--- a/so/mine.c
+++ b/so/mine.c
@@ -49,7 +49,7 @@ void clrtokol(void)
     int n;
     int y, x;
     getyx(&y, &x);
-    for (n = x;n < 17;n++)
+    for (n = x; n < 17; n++)
         outc(' ');
 }
 
@@ -86,7 +86,7 @@ show_fasttime(void)
     char buf[40], *buf1[4] = {"入門級:", "進階級:", "高  級:", "變態級:"};
     fp = fopen("game/mine/mine_fasttime", "r");
     clear();
-    for (i = 0;i < 4;i++)
+    for (i = 0; i < 4; i++)
     {
         fscanf(fp, "%s%d", buf, &fasttime[i]);
         prints("\x1b[1;31m%s  \x1b[1;32m%s %d\x1b[m\n", buf1[i], buf, fasttime[i]);
@@ -103,7 +103,7 @@ load_fasttime(void)
     char buf[40];
     FILE *fp;
     fp = fopen("game/mine/mine_fasttime", "r");
-    for (i = 0;i < 4;i++)
+    for (i = 0; i < 4; i++)
     {
         fscanf(fp, "%s%d", buf, &fasttime[i]);
     }
@@ -118,7 +118,7 @@ change_fasttime(int n, int t)
     char buf[4][40];
     FILE *fp;
     fp = fopen("game/mine/mine_fasttime", "r");
-    for (i = 0;i < 4;i++)
+    for (i = 0; i < 4; i++)
     {
         fscanf(fp, "%s%d", buf[i], &fasttime[i]);
     }
@@ -126,7 +126,7 @@ change_fasttime(int n, int t)
     fasttime[n] = t;
     fclose(fp);
     fp = fopen("game/mine/mine_fasttime", "w");
-    for (i = 0;i < 4;i++)
+    for (i = 0; i < 4; i++)
     {
         fprintf(fp, "%s %d\n", buf[i], fasttime[i]);
     }
@@ -172,24 +172,24 @@ void drawInfo(void)
 void drawPrompt(void)
 {
     int i;
-    for (i = 1;i <= 20;i++)
+    for (i = 1; i <= 20; i++)
     {
         move(i, 0);
         clrtokol();
     }
     vs_bar("踩地雷");
     move(3, 0);
-    outs("按鍵說明:");clrtokol();
+    outs("按鍵說明:"); clrtokol();
     move(4, 0);
-    outs("移動     方向鍵");clrtokol();
+    outs("移動     方向鍵"); clrtokol();
     move(5, 0);
-    outs("翻開     空白鍵");clrtokol();
+    outs("翻開     空白鍵"); clrtokol();
     move(6, 0);
-    outs("標記地雷   ｍ");clrtokol();
+    outs("標記地雷   ｍ"); clrtokol();
     move(7, 0);
-    outs("掃雷       ｔ");clrtokol();
+    outs("掃雷       ｔ"); clrtokol();
     move(9, 0);
-    outs("離開    Esc / q");clrtokol();
+    outs("離開    Esc / q"); clrtokol();
 }
 
 void drawMapLine(int y, int flShow)

--- a/test/Makefile
+++ b/test/Makefile
@@ -40,10 +40,10 @@ testsize: testsize.o
 	$(CC) $(MAKEFLAG) -o $@ $? $(LDFLAGS)
 
 test:
-	@echo -e "\n"; for i in $(EXE); do ./$$i && echo -e "\x1b[1;32m$$i test done!\x1b[0m\n" || ( echo -e "\x1b[1;31m$$i test failed!\n\x1b[0m" && exit 1 ); done
+	@printf "\n"; for i in $(EXE); do ./$$i && printf "\033[1;32m$$i test done!\033[0m\n" || ( printf "\033[1;31m$$i test failed!\n\033[0m" && exit 1 ); done
 
 sizetest:
-	@echo -e "\n"; ./testsize && echo -e "\x1b[1;32msize test done!\x1b[0m\n" || ( echo -e "\x1b[1;31msize test failed!\n\x1b[0m" && exit 1 )
+	@printf "\n"; ./testsize && printf "\033[1;32msize test done!\033[0m\n" || ( printf "\033[1;31msize test failed!\n\033[0m" && exit 1 )
 
 clean:
 	rm -fr $(EXE) *.o *.bak *.BAK *.log *~


### PR DESCRIPTION
It turned out that it was compiling with M3_USE_PFTERM rather than using WSL that caused so/mine.c to fail.
so/mine.c was using `cur_col` instead of calling an API function, which causing this problem.

These commits add spaces after some semicolons as well.