### PR TITLE
Fix Pack 003 Stage 5 APPEND: UNCONSCIOUS KARMA

### DIFF
--- a/maple/board.c
+++ b/maple/board.c
@@ -1410,19 +1410,40 @@ static int
 class_yank2(
     XO *xo)
 {
+    int pos = xo->pos;
     if (xo->key >= 0)
         return XO_NONE;
 
     class_flag2 ^= 0x01;
-    return class_init(xo);
+    if (!class_load(xo) && (class_flag2 & 0x01))
+    {
+        zmsg("找不到可讀的秘密/好友看板");
+        class_flag2 ^= 0x01;
+        class_load(xo);
+        xo->pos = pos;
+        return XO_NONE;
+    }
+    return class_head(xo);
 }
 
 static int
 class_yank(
     XO *xo)
 {
+    int pos = xo->pos;
+    if (xo->key >= 0)
+        return XO_NONE;
+
     class_flag ^= BFO_YANK;
-    return class_init(xo);
+    if (!class_load(xo) && !(class_flag & BFO_YANK))
+    {
+        zmsg("找不到未被 zap 掉的看板");
+        class_flag |= BFO_YANK;
+        class_load(xo);
+        xo->pos = pos;
+        return XO_NONE;
+    }
+    return class_head(xo);
 }
 
 static int

--- a/maple/board.c
+++ b/maple/board.c
@@ -956,7 +956,7 @@ class_check(
         max++;
     } while (chead < ctail);
 
-    if (bnum > 0)
+    if (class_hot && bnum > 0)
         qsort(cbase - bnum, bnum, sizeof(short), mantime_cmp);
 
     return max;

--- a/maple/board.c
+++ b/maple/board.c
@@ -1040,7 +1040,7 @@ class_load(
             // 即時熱門看板臨界值自定
             if (class_hot)
             {
-                if ( ( bshm->mantime[chn] < CLASS_HOT ) && ( !strcmp(brd[chn].brdname, "SYSOP") ) ) /* 只列出人氣超過 CLASS_HOT 的看板 */
+                if (bshm->mantime[chn] < CLASS_HOT) /* 只列出人氣超過 CLASS_HOT 的看板 */
                     continue;
                 bnum++;
             }

--- a/maple/board.c
+++ b/maple/board.c
@@ -1079,8 +1079,22 @@ XoClass(
     xo.xyz = NULL;
     if (!class_load(&xo))
     {
-        free(xo.xyz);
-        return XO_NONE;
+        int ret = 0;
+        if (!ret && (class_flag2 & 0x01))
+        {
+            class_flag2 ^= 0x01;
+            ret = class_load(&xo);
+        }
+        if (!ret && !(class_flag & BFO_YANK))
+        {
+            class_flag |= BFO_YANK;
+            ret = class_load(&xo);
+        }
+        if (!ret)
+        {
+            free(xo.xyz);
+            return XO_NONE;
+        }
     }
 
     xt = xz[XZ_CLASS - XO_ZONE].xo;
@@ -1128,7 +1142,24 @@ class_body(
 
     max = xo->max;
     if (max <= 0)
-        return XO_QUIT;
+    {
+        int ret = class_load(xo);
+        if (!ret && (class_flag2 & 0x01))
+        {
+            class_flag2 ^= 0x01;
+            ret = class_load(xo);
+        }
+        if (!ret && !(class_flag & BFO_YANK))
+        {
+            class_flag |= BFO_YANK;
+            ret = class_load(xo);
+        }
+        if (!ret)
+        {
+            return XO_QUIT;
+        }
+        return XO_BODY;
+    }
 
 
     cnt = xo->top;

--- a/maple/board.c
+++ b/maple/board.c
@@ -931,7 +931,8 @@ class_check(
             {
                 if (class_flag2 &&
                     (!(val & BRD_R_BIT) || !(brd[chn].brdname[0]) ||
-                    (brd[chn].readlevel & ~(PERM_SYSOP | PERM_BOARD)) ))
+                    !(brd[chn].readlevel) || (brd[chn].readlevel & ~(PERM_SYSOP | PERM_BOARD)) ))
+
                         continue;
 
                 if ((val & BRD_F_BIT) && !(val & zap))
@@ -1026,7 +1027,7 @@ class_load(
             {
                 if (class_flag2 &&
                     (!(val & BRD_R_BIT) || !(brd[chn].brdname[0]) ||
-                    (brd[chn].readlevel & ~(PERM_SYSOP | PERM_BOARD)) ))
+                    !(brd[chn].readlevel) || (brd[chn].readlevel & ~(PERM_SYSOP | PERM_BOARD)) ))
                         continue;
 
                 if ((val & BRD_F_BIT) && !(val & zap))

--- a/maple/board.c
+++ b/maple/board.c
@@ -864,7 +864,6 @@ mantime_cmp(
     return bshm->mantime[* (const short *)b] - bshm->mantime[* (const short *)a];
 }
 
-static int class_hot = 0;
 static int class_flag2 = 0;  /* 1:列出好友/秘密板，且自己又有閱讀權限的 */
 static int class_flag;
 
@@ -877,6 +876,7 @@ class_check(
     short *cbase, *chead, *ctail;
     int pos, max, val, zap;
     int bnum = 0;
+    int class_hot = 0;
     BRD *brd;
     char *bits;
 
@@ -901,6 +901,13 @@ class_check(
 #endif
         default:
             cbase = (short *) class_img;
+    }
+
+    // "HOT/" 名稱可自定，若改名也要順便改後面的長度 4
+    if (!strncmp((char *)cbase + cbase[chn], "HOT/", 4))
+    {
+        class_hot = 1;
+        chn = 0;
     }
 
     chead = cbase + chn;
@@ -971,6 +978,7 @@ class_load(
     int chn;                    /* ClassHeader number */
     int pos, max, val, zap;
     int bnum = 0;
+    int class_hot = 0;
     BRD *brd;
     char *bits;
 
@@ -993,6 +1001,13 @@ class_load(
 #endif
         default:
             cbase = (short *) class_img;
+    }
+
+    // "HOT/" 名稱可自定，若改名也要順便改後面的長度 4
+    if (!strncmp((char *)cbase + cbase[chn], "HOT/", 4))
+    {
+        class_hot = 1;
+        chn = 0;
     }
 
     chead = cbase + chn;
@@ -1543,19 +1558,8 @@ class_browse(
         chx = (short *) img + (CH_END - chn);
         str = img + *chx;
 
-        // "HOT/" 名稱可自定，若改名也要順便改後面的長度 4
-        if (!strncmp(str, "HOT/", 4))
-        {
-            class_hot = 1;
-            chn = CH_END;
-        }
-
         if (XoClass(chn) == XO_NONE)
             return XO_NONE;
-
-        if (class_hot)
-            class_hot = 0;      /* 離開 HOT Class 再清除 class_hot 標記 */
-
     }
     else
     {

--- a/maple/edit.c
+++ b/maple/edit.c
@@ -749,7 +749,7 @@ tbf_open(int n)
     int ans;
     char fpath[64], op[4];
 
-    usr_fpath(fpath, cuser.userid, tbf_ask(-1));
+    usr_fpath(fpath, cuser.userid, tbf_ask(n));
     ans = 'a';
 
     if (dashf(fpath))

--- a/maple/edit.c
+++ b/maple/edit.c
@@ -2075,7 +2075,7 @@ ve_key:
             case Meta('3'):
             case Meta('4'):
             case Meta('5'):
-                tbf_read(cc - '0');
+                tbf_read(cc - Meta('0'));
                 ve_mode = mode | VE_REDRAW;
                 continue;
 

--- a/maple/xchatd.c
+++ b/maple/xchatd.c
@@ -1861,8 +1861,8 @@ login_user(
     /* Thor.990214: 注意, daolib中 非0代表失敗 */
     /* if (!chkpasswd(acct.passwd, acct.passhash, passwd)) */
     if ((strncmp(passwd, acct.passwd, PASSLEN-1)
-          || strlen(passwd) < PASSLEN
-          || strncmp(passwd + PASSLEN - 1, acct.passhash, sizeof(acct.passhash)))
+          || (strlen(passwd) >= PASSLEN
+              && strncmp(passwd + PASSLEN - 1, acct.passhash, sizeof(acct.passhash))))
         && chkpasswd(acct.passwd, acct.passhash, passwd))
     {
 


### PR DESCRIPTION
This pull request contains fixes for several bugs introduced in PR #53.
Please see the changelogs below for details.

# Fixpack 003 Stage 5 APPEND Changelog (en-us):

### For "Stable" and "Current" versions

- Fix the hottest board listing all the boards except the board 'SYSOP'
      as well as the board 'SYSOP' when it is hot;
   now it lists all hot boards
- Fix the issue that `class_yank2()` (the `i` function)
   always list all boards of which the user has the read permission
- Fix the issue that using `class_yank()` (the `y` function) or `class_yank2()` (the `i` function) causes the user to be kicked out of the board list when there are no corresponding boards 
- Fix the issue that the user cannot enter the board list if `class_yank()` or `class_yank2()` is activated and there are no corresponding boards
- Fix the issue that an empty hottest board list prevents the user from entering the board category list
- Editor: Fix redundant prompts for file selection when using key shortcuts `ESC-1`-`ESC-5`. 

### For "Current" version

- Fix the issue that DES-encrypted passwords cannot be used to login xchatd

# Fixpack 003 Stage 5 APPEND Changelog (zh-tw):

### 針對「Stable」和「Current」版的修正

- 修正熱門看板會列出所有非 SYSOP 的看板以及熱門的看板 SYSOP 的問題；
   應為列出所有熱門看板
- 修正 `class_yank2()` (只顯示好友板、秘密板) 會列出可閱讀的所有看板的問題
- 修正：使用 `class_yank()` (顯示被 zap 掉的板) 或是 `class_yank2()` (只顯示好友板、秘密板) 時，如果沒有相符的看板，就會造成使用者被踢出看板列表的問題。 
- 修正：`class_yank()` 或是 `class_yank2()` 作用中時，如果沒有相符的看板，就會導致使用者無法進入看板列表的問題。
- 修正空的熱門看板列表會造成使用者無法進入分類看板列表的問題
- 編輯器：修正使用快速鍵 `ESC-1`~`ESC-5` 會出現多餘的檔案選擇訊息的問題。

### 針對「Current」版的修正

- 解決使用 DES 加密的密碼無法用以登入 xchatd 的問題