### PR TITLE
maple/bbsd.c: remove dash after load message

### DIFF
--- a/maple/bbsd.c
+++ b/maple/bbsd.c
@@ -1163,7 +1163,7 @@ tn_main(void)
 
     //getloadavg(load, 3);
     prints( MYHOSTNAME " ◇ " OWNER " ◇ " BBSIP " [" BBSVERNAME " " BBSVERSION "]\n"
-"舧羬\x1b[1;33;46m %s \x1b[m╰参璽更%.2f %.2f %.2f / %ld - [%s] 絬计 [%d/%d]",
+"舧羬\x1b[1;33;46m %s \x1b[m╰参璽更%.2f %.2f %.2f / %ld [%s] 絬计 [%d/%d]",
         str_site, load[0], load[1], load[2], nproc, load_norm>5?"\x1b[1;37;41m筁蔼\x1b[m":load_norm>1?"\x1b[1;37;42m熬蔼\x1b[m":"\x1b[1;37;44mタ盽\x1b[m", ushm->count, MAXACTIVE);
 
     film_out(FILM_INCOME, 2);


### PR DESCRIPTION
Before:
![圖片](https://user-images.githubusercontent.com/19514836/68227764-3c19ad00-002f-11ea-8f83-f7c2ac3b0965.png)

After:
![圖片](https://user-images.githubusercontent.com/19514836/68227798-49cf3280-002f-11ea-9d4f-c153e5d2ddc1.png)

Apply to: `master`, `v2.0-artoria`