### PR TITLE
Fix Pack 005b: Gamma Correction

### DIFF
--- a/include/config.h
+++ b/include/config.h
@@ -524,9 +524,9 @@
 #define MOVIE_LINES     (11)            /* 動畫最多有 11 列 */
 
 #define MENU_NOMOVIE_POS(y, x)  (y < (MOVIE_LINES + 2))  /* Suppress movie display when menu starts at (x, y) */
-#define MENU_XPOS       (d_cols / 2U + 23)    /* 選單開始的 (y, x) 座標 */
+#define MENU_XPOS       ((d_cols >> 1) + 23)  /* 選單開始的 (y, x) 座標 */
 #define MENU_YPOS       13
-#define MENU_XPOS_REF   (D_COLS_REF / 2U + 23)  /* For `get[y|x]_ref()` & `move_ref()` */
+#define MENU_XPOS_REF   ((D_COLS_REF >> 1) + 23)  /* For `get[y|x]_ref()` & `move_ref()` */
 #define MENU_YPOS_REF   13
 #define MENU_LOAD       1
 #define MENU_DRAW       2

--- a/include/global.h
+++ b/include/global.h
@@ -376,8 +376,9 @@
 
 
 //#define STR_CURSOR      "¡´"
-#define STR_CURSOR      "> "
-#define STR_UNCUR       "  "
+//#define STR_UNCUR       "  "  // Needs to be as wide as `STR_CURSOR`
+#define STR_CURSOR      ">"
+#define STR_UNCUR       " "
 #define STR_SPACE       " \t\n\r"
 
 #define STR_AUTHOR1     "§@ªÌ:"

--- a/include/proto.h
+++ b/include/proto.h
@@ -356,13 +356,13 @@ int Ext_POP3_Check(const char *site, const char *account, const char *passwd);
 int pmore(const char *fpath, int promptend);
 #endif  /* #ifdef M3_USE_PMORE */
 /* popupmenu.c */
-int popupmenu_ans(const char *const desc[], const char *title, int y, int x);
-void popupmenu(MENU pmenu[], XO *xo, int y, int x);
+int popupmenu_ans(const char *const desc[], const char *title, int y_ref, int x_ref);
+void popupmenu(MENU pmenu[], XO *xo, int y_ref, int x_ref);
 void pmsg_body(const char *msg);
 int pmsg(const char *msg);
 int Every_Z_Screen(void);
 /* window.c */
-int popupmenu_ans2(const char *const desc[], const char *title, int y, int x);
+int popupmenu_ans2(const char *const desc[], const char *title, int y_ref, int x_ref);
 void pmsg2_body(const char *msg);
 int pmsg2(const char *msg);
 /* myfavorite.c */

--- a/innbbsd/channel.c
+++ b/innbbsd/channel.c
@@ -375,7 +375,7 @@ channelreader(
     if (len < ReadSize + 3)
     {
         len += (used + ReadSize);
-        len += (len / 8U);
+        len += (len >> 3);
 
         in->data = data = (char *) realloc(data, len);
         len -= used;

--- a/lib/xsort.c
+++ b/lib/xsort.c
@@ -77,7 +77,7 @@ void xsort(void *a, size_t n, size_t es, int (*cmp) (const void *lhs, const void
         pn = (char *)a + (n - 1) * es;
         if (n > 40)
         {
-            d = (n / 8U) * es;
+            d = (n >> 3) * es;
             pl = med3(pl, pl + d, pl + d + d, cmp);
             pm = med3(pm - d, pm, pm + d, cmp);
             pn = med3(pn - 2 * d, pn - d, pn, cmp);

--- a/maple/acct.c
+++ b/maple/acct.c
@@ -268,7 +268,7 @@ void x_file(int mode,            /* M_XFILES / M_UFILES */
     if (mode == M_UFILES)
         domenu(list, MENU_YPOS_REF, MENU_XPOS_REF, 0, 0, 1);
     else
-        domenu(list, (B_LINES_REF-19)/2U, 0, 20, T_COLS_REF/2U, 2);
+        domenu(list, ((B_LINES_REF-19) >> 1), 0, 20, T_COLS_REF >> 1, 2);
 
     for (MENU *mptr = list; mptr->item.func; mptr++)
         free((char *)mptr->desc);
@@ -347,7 +347,7 @@ unsigned int bitset(unsigned int pbits, int count,    /* 共有幾個選項 */
             else
                 pbits ^= j;
         }
-        move(5 + (i % 16U), (i < 16 ? 0 : (b_cols+1) / 2U));
+        move(5 + (i % 16U), (i < 16 ? 0 : (b_cols+1) >> 1));
         if (perms[i])
             prints("%c %s %s", radix32[i], msg, perms[i]);
         else
@@ -378,7 +378,7 @@ unsigned int bitset(unsigned int pbits, int count,    /* 共有幾個選項 */
             }
 
             pbits ^= j;
-            move(5 + (i % 16U), (i < 16 ? 0 : (b_cols+1) / 2U) + 2);
+            move(5 + (i % 16U), (i < 16 ? 0 : (b_cols+1) >> 1) + 2);
             outs(msg);
         }
     }

--- a/maple/bbsd.c
+++ b/maple/bbsd.c
@@ -859,7 +859,7 @@ tn_login(void)
                 level &= ~PERM_CHAT;
 
 /*
-            if ((cuser.numemail / 16U) > (cuser.numlogins + cuser.numposts))
+            if ((cuser.numemail >> 4) > (cuser.numlogins + cuser.numposts))
                 level |= PERM_DENYMAIL;*/
         }
 

--- a/maple/board.c
+++ b/maple/board.c
@@ -38,7 +38,7 @@ brh_alloc(
     if (size > brh_size)
     {
         /* size = (size & -BRH_PAGE) + BRH_PAGE; */
-        size += n / 16U;        /* 多預約一些記憶體 */
+        size += n >> 4;         /* 多預約一些記憶體 */
         base = (int *) realloc((char *) base, size);
 
         if (base == NULL)

--- a/maple/cache.c
+++ b/maple/cache.c
@@ -562,7 +562,7 @@ observeshm_find(
     {
         for (count = oshm->total; count > 0;)
         {
-            datum = cache[mid = count / 2U];
+            datum = cache[mid = count >> 1];
             if (userno == datum)
                 return 1;
             if (userno > datum)
@@ -761,7 +761,7 @@ out_rle(
     else
         getyx(&y, &SINKVAL(int));
 
-    move(y, d_cols / 2U /*item_length[count++]*/);
+    move(y, d_cols >> 1/*item_length[count++]*/);
     while ((cc = (unsigned char) *str))
     {
         str++;
@@ -780,7 +780,7 @@ out_rle(
                         outs("\x1b[m");
                         clrtoeol();
                     }
-                    move(++y, d_cols / 2U /*item_length[count++]*/);
+                    move(++y, d_cols >> 1/*item_length[count++]*/);
                 }
                 else
                     outc(cc);
@@ -811,7 +811,7 @@ out_rle(
                 outs("\x1b[m");
                 clrtoeol();
             }
-            move(++y, d_cols / 2U /*item_length[count++]*/);
+            move(++y, d_cols >> 1/*item_length[count++]*/);
 
         }
         else

--- a/maple/edit.c
+++ b/maple/edit.c
@@ -1427,11 +1427,11 @@ ve_filer(
 //  else
 //  {
         if (bbsmode != M_POST)
-            re = popupmenu_ans2(menu1, "存檔選項", b_lines/2U - 7, d_cols/2U + 20);
+            re = popupmenu_ans2(menu1, "存檔選項", B_LINES_REF/2U - 7, D_COLS_REF/2U + 20);
         else if (curredit & EDIT_OUTGO)
-            re = popupmenu_ans2(menu2, "存檔選項", b_lines/2U - 7, d_cols/2U + 20);
+            re = popupmenu_ans2(menu2, "存檔選項", B_LINES_REF/2U - 7, D_COLS_REF/2U + 20);
         else
-            re = popupmenu_ans2(menu3, "存檔選項", b_lines/2U - 7, d_cols/2U + 20);
+            re = popupmenu_ans2(menu3, "存檔選項", B_LINES_REF/2U - 7, D_COLS_REF/2U + 20);
 
 //  }
 
@@ -2190,7 +2190,7 @@ ve_key:
                         NULL
                     };
 
-                    switch (cc = popupmenu_ans2(menu, "控制碼選擇", b_lines/2U - 4, d_cols/2U + 20))
+                    switch (cc = popupmenu_ans2(menu, "控制碼選擇", B_LINES_REF/2U - 4, D_COLS_REF/2U + 20))
                     {
                     case 'i':
                         ve_char(KEY_ESC);

--- a/maple/edit.c
+++ b/maple/edit.c
@@ -1190,7 +1190,7 @@ quote_check(void)
         checkqt--;
 #endif
 
-    if ((quot_line / 4U) <= post_line)
+    if ((quot_line >> 2) <= post_line)
         return 0;
 
 /*  if (HAS_PERM(PERM_SYSOP))*/
@@ -1427,11 +1427,11 @@ ve_filer(
 //  else
 //  {
         if (bbsmode != M_POST)
-            re = popupmenu_ans2(menu1, "存檔選項", B_LINES_REF/2U - 7, D_COLS_REF/2U + 20);
+            re = popupmenu_ans2(menu1, "存檔選項", (B_LINES_REF >> 1) - 7, (D_COLS_REF >> 1) + 20);
         else if (curredit & EDIT_OUTGO)
-            re = popupmenu_ans2(menu2, "存檔選項", B_LINES_REF/2U - 7, D_COLS_REF/2U + 20);
+            re = popupmenu_ans2(menu2, "存檔選項", (B_LINES_REF >> 1) - 7, (D_COLS_REF >> 1) + 20);
         else
-            re = popupmenu_ans2(menu3, "存檔選項", B_LINES_REF/2U - 7, D_COLS_REF/2U + 20);
+            re = popupmenu_ans2(menu3, "存檔選項", (B_LINES_REF >> 1) - 7, (D_COLS_REF >> 1) + 20);
 
 //  }
 
@@ -2190,7 +2190,7 @@ ve_key:
                         NULL
                     };
 
-                    switch (cc = popupmenu_ans2(menu, "控制碼選擇", B_LINES_REF/2U - 4, D_COLS_REF/2U + 20))
+                    switch (cc = popupmenu_ans2(menu, "控制碼選擇", (B_LINES_REF >> 1) - 4, (D_COLS_REF >> 1) + 20))
                     {
                     case 'i':
                         ve_char(KEY_ESC);

--- a/maple/gem.c
+++ b/maple/gem.c
@@ -714,7 +714,7 @@ gbuf_malloc(
     {
         if (GemBufferSiz < num)
         {
-            num += (num / 2U);
+            num += (num >> 1);
             GemBufferSiz = num;
             GemBuffer = gbuf = (HDR *) realloc(gbuf, sizeof(HDR) * num);
         }

--- a/maple/menu.c
+++ b/maple/menu.c
@@ -168,7 +168,7 @@ pad_draw(void)
     len = strlen(str);
     strcat(str, & " \x1b[30;46m"[len % 2U]);
 
-    for (i = len / 2U; i < 41; i++)
+    for (i = len >> 1; i < 41; i++)
         strcat(str, "▄");
     sprintf(str2, "\x1b[34;47m %.14s \x1b[37;46mΥ\x1b[m\n%-70.70s\n%-70.70s\n%-70.70s\n",
         Etime(&(pad.tpad)), buf[0], buf[1], buf[2]);
@@ -274,7 +274,7 @@ vs_mid(
     }
 
     spc = b_cols - len; /* spc: 中間還剩下多長的空間 */
-    pad = spc / 2U; /* pad: Spaces needed to center `mid` */
+    pad = spc >> 1; /* pad: Spaces needed to center `mid` */
 
     prints("%*s%s%*s\x1b[m\n", pad, "", mid, spc - pad, "");
 }
@@ -318,7 +318,7 @@ vs_head(
     spc = b_cols - 14 - len - strlen(currboard); /* spc: 中間還剩下多長的空間 */
     len_ttl = BMIN(len_ttl, spc); /* Truncate `title` if too long */
     spc -= len_ttl; /* 擺完 title 以後，中間還有 spc 格空間 */
-    pad = BMAX((b_cols - len)/2U - (len_ttl + 5), 0U); /* pad: Spaces needed to center `mid` */
+    pad = BMAX(((b_cols - len) >> 1) - (len_ttl + 5), 0); /* pad: Spaces needed to center `mid` */
     pad = BMAX(pad, 0);
 
 #ifdef  COLOR_HEADER

--- a/maple/menu.c
+++ b/maple/menu.c
@@ -319,7 +319,6 @@ vs_head(
     len_ttl = BMIN(len_ttl, spc); /* Truncate `title` if too long */
     spc -= len_ttl; /* 擺完 title 以後，中間還有 spc 格空間 */
     pad = BMAX(((b_cols - len) >> 1) - (len_ttl + 5), 0); /* pad: Spaces needed to center `mid` */
-    pad = BMAX(pad, 0);
 
 #ifdef  COLOR_HEADER
     prints("\x1b[1;%2d;37m【%.*s】%*s \x1b[33m%s\x1b[1;%2d;37m%*s \x1b[37m看板《%s》\x1b[m\n",

--- a/maple/more.c
+++ b/maple/more.c
@@ -525,7 +525,7 @@ more(
 
             lino++;
 
-            if ((lino % 32U == 0) && ((i = lino / 32U) < MAXBLOCK))
+            if ((lino & 31 == 0) && ((i = lino >> 5) < MAXBLOCK))
                 block[i] = foff - fimage;
 
 
@@ -762,12 +762,12 @@ re_key:
                     while (more_line(buf))
                     {
                         totallino++;
-                        if ((totallino % 32U == 0) && ((i = totallino / 32U) < MAXBLOCK))
+                        if ((totallino & 31 == 0) && ((i = totallino >> 5) < MAXBLOCK))
                             block[i] = foff - fimage;
                     }
 
                     /* 先位移到上一個 block 的尾端 */
-                    i = BMIN((totallino - b_lines) / 32U, MAXBLOCK - 1);
+                    i = BMIN((totallino - b_lines) >> 5, MAXBLOCK - 1);
                     foff = fimage + block[i];
                     i = i * 32;
 
@@ -801,7 +801,7 @@ re_key:
                 */
 
                 /* 先位移到上一個 block 的尾端 */
-                i = BMIN((lino - b_lines) / 32U, MAXBLOCK - 1);
+                i = BMIN((lino - b_lines) >> 5, MAXBLOCK - 1);
                 foff = fimage + block[i];
                 i = i * 32;
 

--- a/maple/popupmenu.c
+++ b/maple/popupmenu.c
@@ -635,34 +635,34 @@ void pmsg_body(const char *msg)
     {
         pcopy(patten, "ˍ", plen);
         sprintf(buf, " \x1b[0;40;37mˍˍˍˍˍˍˍˍˍˍˍˍˍˍˍˍˍ%s\x1b[m  ", plen?patten:"");
-        vs_line(buf, b_lines/2U - 4, d_cols/2U + 18-plen);
+        vs_line(buf, (b_lines >> 1) - 4, (d_cols >> 1) + 18-plen);
         pcopy(patten, "  ", plen);
         sprintf(buf, " \x1b[0;37;44m▏ 請按任意鍵繼續 .....         %s\x1b[0;47;34m▉\x1b[m ", plen?patten:"");
-        vs_line(buf, b_lines/2U - 3, d_cols/2U + 18-plen);
+        vs_line(buf, (b_lines >> 1) - 3, (d_cols >> 1) + 18-plen);
         sprintf(buf, " \x1b[0;37m▏                              %s\x1b[0;47;30m▉\x1b[m\x1b[40;30;1m▉\x1b[m ", plen?patten:"");
-        vs_line(buf, b_lines/2U - 2, d_cols/2U + 18-plen);
+        vs_line(buf, (b_lines >> 1) - 2, (d_cols >> 1) + 18-plen);
         sprintf(buf, " \x1b[0;37m▏%-30s%s\x1b[0;47;30m▉\x1b[m\x1b[40;30;1m▉\x1b[m ", msg, ((len > 30 && len%2 == 1) ? " " : ""));
-        vs_line(buf, b_lines/2U - 1, d_cols/2U + 18-plen);
+        vs_line(buf, (b_lines >> 1) - 1, (d_cols >> 1) + 18-plen);
         sprintf(buf, " \x1b[0;37m▏                              %s\x1b[0;47;30m▉\x1b[m\x1b[40;30;1m▉\x1b[m ", plen?patten:"");
-        vs_line(buf, b_lines/2U + 0, d_cols/2U + 18-plen);
+        vs_line(buf, (b_lines >> 1) + 0, (d_cols >> 1) + 18-plen);
         pcopy(patten, "▇", plen);
         sprintf(buf, " \x1b[0;47;30m▇\x1b[30;1m▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇%s\x1b[40;30;1m▉\x1b[m ", plen?patten:"");
-        vs_line(buf, b_lines/2U + 1, d_cols/2U + 18-plen);
+        vs_line(buf, (b_lines >> 1) + 1, (d_cols >> 1) + 18-plen);
     }
     else
     {
         sprintf(buf, " \x1b[0;40;37mˍˍˍˍˍˍˍˍˍˍˍˍˍˍˍˍˍˍ\x1b[m  ");
-        vs_line(buf, b_lines/2U - 4, d_cols/2U + 18);
+        vs_line(buf, (b_lines >> 1) - 4, (d_cols >> 1) + 18);
         sprintf(buf, " \x1b[0;37;44m▏ 請按任意鍵繼續 .....           \x1b[0;47;34m▉\x1b[m ");
-        vs_line(buf, b_lines/2U - 3, d_cols/2U + 18);
+        vs_line(buf, (b_lines >> 1) - 3, (d_cols >> 1) + 18);
         sprintf(buf, " \x1b[0;37m▏                                \x1b[0;47;30m▉\x1b[m\x1b[40;30;1m▉\x1b[m ");
-        vs_line(buf, b_lines/2U - 2, d_cols/2U + 18);
+        vs_line(buf, (b_lines >> 1) - 2, (d_cols >> 1) + 18);
         sprintf(buf, " \x1b[0;37m▏%-30s  \x1b[0;47;30m▉\x1b[m\x1b[40;30;1m▉\x1b[m ", "[請按任意鍵繼續]");
-        vs_line(buf, b_lines/2U - 1, d_cols/2U + 18);
+        vs_line(buf, (b_lines >> 1) - 1, (d_cols >> 1) + 18);
         sprintf(buf, " \x1b[0;37m▏                                \x1b[0;47;30m▉\x1b[m\x1b[40;30;1m▉\x1b[m ");
-        vs_line(buf, b_lines/2U + 0, d_cols/2U + 18);
+        vs_line(buf, (b_lines >> 1) + 0, (d_cols >> 1) + 18);
         sprintf(buf, " \x1b[0;47;30m▇\x1b[30;1m▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇\x1b[40;30;1m▉\x1b[m ");
-        vs_line(buf, b_lines/2U + 1, d_cols/2U + 18);
+        vs_line(buf, (b_lines >> 1) + 1, (d_cols >> 1) + 18);
     }
 }
 

--- a/maple/post.c
+++ b/maple/post.c
@@ -3930,7 +3930,7 @@ post_manage(
 
     grayout(0, b_lines, GRAYOUT_DARK);
 
-    switch (re = popupmenu_ans2(menu, "板主管理", b_lines/2U - 8, d_cols/2U + 20))
+    switch (re = popupmenu_ans2(menu, "板主管理", B_LINES_REF/2U - 8, D_COLS_REF/2U + 20))
     {
         case 't':
             return post_brdtitle(xo);

--- a/maple/post.c
+++ b/maple/post.c
@@ -3930,7 +3930,7 @@ post_manage(
 
     grayout(0, b_lines, GRAYOUT_DARK);
 
-    switch (re = popupmenu_ans2(menu, "板主管理", B_LINES_REF/2U - 8, D_COLS_REF/2U + 20))
+    switch (re = popupmenu_ans2(menu, "板主管理", (B_LINES_REF >> 1) - 8, (D_COLS_REF >> 1) + 20))
     {
         case 't':
             return post_brdtitle(xo);
@@ -4682,7 +4682,7 @@ XoXpost(                        /* Thor: call from post_cb */
                 break;
             }
 
-            mid = (left + right) / 2U;
+            mid = (left + right) >> 1;
             cptr = &chain[mid];
             cmp = strcmp(title, cptr->subject);
 

--- a/maple/talk.c
+++ b/maple/talk.c
@@ -168,7 +168,7 @@ can_see(
     {
         for (count = up->pal_max; count > 0;)
         {
-            datum = cache[mid = count / 2U];
+            datum = cache[mid = count >> 1];
             if ((-cuser.userno) == datum)
                 return 2;
             if ((-cuser.userno) > datum)
@@ -186,7 +186,7 @@ can_see(
     {
         for (count = up->pal_max; count > 0;)
         {
-            datum = cache[mid = count / 2U];
+            datum = cache[mid = count >> 1];
             if (cuser.userno == datum)
                 return 1;
             if (cuser.userno > datum)
@@ -215,7 +215,7 @@ is_bad(
     {
         for (count = pal_count; count > 0;)
         {
-            datum = cache[mid = count / 2U];
+            datum = cache[mid = count >> 1];
             if ((-userno) == datum)
                 return true;
             if ((-userno) > datum)
@@ -244,7 +244,7 @@ can_banmsg(
     {
         for (count = up->banmsg_max; count > 0;)
         {
-            datum = cache[mid = count / 2U];
+            datum = cache[mid = count >> 1];
             if (cuser.userno == datum)
                 return true;
             if (cuser.userno > datum)
@@ -355,7 +355,7 @@ is_pal(
     {
         for (count = pal_count; count > 0;)
         {
-            datum = cache[mid = count / 2U];
+            datum = cache[mid = count >> 1];
             if (userno == datum)
                 return true;
             if (userno > datum)
@@ -384,7 +384,7 @@ is_banmsg(
     {
         for (count = cutmp->banmsg_max; count > 0;)
         {
-            datum = cache[mid = count / 2U];
+            datum = cache[mid = count >> 1];
             if (userno == datum)
                 return true;
             if (userno > datum)
@@ -1354,7 +1354,7 @@ bm_belong(
 
             while (count > 0)
             {
-                datum = up[mid = count / 2U];
+                datum = up[mid = count >> 1];
                 if (userno == datum)
                 {
                     result = BRD_R_BIT | BRD_W_BIT;
@@ -1374,7 +1374,7 @@ bm_belong(
             up = (int *) board_img;
             while (wcount > 0)
             {
-                datum = up[mid = wcount / 2U];
+                datum = up[mid = wcount >> 1];
                 if (-userno == datum)
                 {
                     result = BRD_R_BIT;
@@ -2552,7 +2552,7 @@ talk_speak(
     memset(&mywin, 0, sizeof(mywin));
     memset(&itswin, 0, sizeof(itswin));
 
-    ch = b_lines / 2U;
+    ch = b_lines >> 1;
     mywin.eline = ch - 1;
     itswin.curln = itswin.sline = ch + 1;
     itswin.eline = b_lines - 1;
@@ -2560,7 +2560,7 @@ talk_speak(
     clear();
     move(ch, 0);
     prints("\x1b[1;46;37m  談天說地  \x1b[45m%*s%s】 ◆  %s%*s\x1b[m",
-        i/2U, "", buf, page_requestor, (i+1)/2U, "");
+        i>>1, "", buf, page_requestor, (i+1)>>1, "");
 #if 1
     outf(FOOTER_TALK);
 #endif
@@ -3149,9 +3149,9 @@ ulist_body(
                 prints("%6d%c%s%-13s%-*.*s%s%-*.*s%c%c %-12.12s %5.5s",
                     cnt, (up->ufo & UFO_WEB)?'*':' ',
                     color, up->userid,
-                    d_cols/2U + 22, d_cols/2U + 21, (HAS_PERM(PERM_SYSOP) && (cuser.ufo2 & UFO2_REALNAME))? up->realname : up->username,
+                    (d_cols >> 1) + 22, (d_cols >> 1) + 21, (HAS_PERM(PERM_SYSOP) && (cuser.ufo2 & UFO2_REALNAME))? up->realname : up->username,
                     colortmp > 0 ? "\x1b[m" : "",
-                    (d_cols+1)/2U + 16, (d_cols+1)/2U + 15,
+                    ((d_cols+1) >> 1) + 16, ((d_cols+1) >> 1) + 15,
                     (cuser.ufo2 & UFO2_SHIP) ? ship : ((up->ufo & UFO_HIDDEN)&&!HAS_PERM(PERM_SYSOP)) ?
                     HIDDEN_SRC : up->from, diff, diffmsg,
                     bmode(up, 0), buf);
@@ -3367,14 +3367,14 @@ ulist_neck(
     prints("  排列方式：[\x1b[1m%s\x1b[m] 上站人數：%d %s我的朋友：%d %s與我為友：%d %s壞人：%d \x1b[0;36m板友：%d\x1b[m",
         msg_pickup_way[pickup_way], total_num, COLOR_PAL, friend_num+pfriend_num, COLOR_OPAL, friend_num+ofriend_num, COLOR_BAD, bfriend_num, board_pals);
     prints(NECK_ULIST,
-        d_cols/2U + 22, (HAS_PERM(PERM_SYSOP) && (cuser.ufo2 & UFO2_REALNAME)) ? "真實姓名" : "暱  稱",
-        (d_cols+1)/2U + 13, (cuser.ufo2 & UFO2_SHIP) ? "好友描述" :"故鄉", "動態");
+        (d_cols >> 1) + 22, (HAS_PERM(PERM_SYSOP) && (cuser.ufo2 & UFO2_REALNAME)) ? "真實姓名" : "暱  稱",
+        ((d_cols+1) >> 1) + 13, (cuser.ufo2 & UFO2_SHIP) ? "好友描述" :"故鄉", "動態");
 #else
     prints("  排列方式：[\x1b[1m%s\x1b[m] 上站人數：%d %s我的朋友：%d %s與我為友：%d %s壞人：%d\x1b[m",
         msg_pickup_way[pickup_way], total_num, COLOR_PAL, friend_num+pfriend_num, COLOR_OPAL, friend_num+ofriend_num, COLOR_BAD, bfriend_num);
     prints(NECK_ULIST,
-        d_cols/2U + 22, (HAS_PERM(PERM_SYSOP) && (cuser.ufo & UFO_REALNAME)) ? "真實姓名" : "暱  稱",
-        (d_cols+1)/2U + 13, (cuser.ufo2 & UFO2_SHIP) ? "好友描述" :"故鄉", "動態");
+        (d_cols >> 1) + 22, (HAS_PERM(PERM_SYSOP) && (cuser.ufo & UFO_REALNAME)) ? "真實姓名" : "暱  稱",
+        ((d_cols+1) >> 1) + 13, (cuser.ufo2 & UFO2_SHIP) ? "好友描述" :"故鄉", "動態");
 #endif
 
     return ulist_body(xo);

--- a/maple/visio.c
+++ b/maple/visio.c
@@ -1387,7 +1387,7 @@ vmsg_body(
         color =time(0)%6+31;
         prints("\x1b[1;%dm%*s▏▎▍▌▋▊▉ \x1b[1;37m請按任意鍵繼續 \x1b[1;%dm▉\x1b[m ", color, d_cols + 47, "", color);
 #else
-        outs(VMSG_NULL, d_cols/2U + 30, "", (d_cols+1)/2U + 29, "");
+        outs(VMSG_NULL, (d_cols >> 1) + 30, "", (d_cols+1 >> 1) + 29, "");
 #endif
 #ifdef M3_USE_PFTERM
         move(b_lines, 0);
@@ -1530,13 +1530,13 @@ vs_line(
     int head, tail;
 
     if (msg)
-        head = (strlen(msg) + 1) / 2U;
+        head = (strlen(msg) + 1) >> 1;
     else
         head = 0;
 
     tail = head;
 
-    while (head++ < b_cols / 2U - 1)
+    while (head++ < (b_cols >> 1) - 1)
         outc('-');
 
     if (tail)
@@ -1546,7 +1546,7 @@ vs_line(
         outc(' ');
     }
 
-    while (tail++ < (b_cols+1) / 2U - 1)
+    while (tail++ < ((b_cols+1) >> 1) - 1)
         outc('-');
     outc('\n');
 }
@@ -2677,7 +2677,7 @@ vkey(void)
             else
             {
                 vio_to = seq_tv;
-                seq_tv.tv_usec /= 2U;  /* Prevent infinity escape sequences */
+                seq_tv.tv_usec >>= 1;  /* Prevent infinity escape sequences */
             }
 
             mode = 1;
@@ -2695,7 +2695,7 @@ vkey(void)
 #ifdef  TRAP_ESC
             else if (ch == KEY_ESC) /* "<Esc> <Esc>" */ /* <Esc> + possible special keys */
             {
-                seq_tv.tv_usec /= 2U;  /* Prevent infinity "<Esc>..." */
+                seq_tv.tv_usec >>= 1;  /* Prevent infinity "<Esc>..." */
                 mod = META_CODE;       /* Make the key Meta-ed */
             }
 #endif

--- a/maple/window.c
+++ b/maple/window.c
@@ -328,9 +328,11 @@ find_cur(               /* 找 ch 這個按鍵是第幾個選項 */
 /*       最後一個字串必須為 NULL                         */
 /*------------------------------------------------------ */
 
+/* IID.20200204: Use screen size referencing coordinate */
 int             /* 傳回小寫字母或數字 */
-popupmenu_ans2(const char *const desc[], const char *title, int y, int x)
+popupmenu_ans2(const char *const desc[], const char *title, int y_ref, int x_ref)
 {
+    int y, x;
     int cur, old_cur, max, ch;
     char hotkey;
 
@@ -340,6 +342,9 @@ popupmenu_ans2(const char *const desc[], const char *title, int y, int x)
     x_roll =
 #endif
     scr_dump(&old_screen);
+
+    y = gety_ref(y_ref);
+    x = getx_ref(x_ref);
 
     grayout(0, b_lines, GRAYOUT_DARK);
 
@@ -354,7 +359,24 @@ popupmenu_ans2(const char *const desc[], const char *title, int y, int x)
 
     while (1)
     {
-        switch (ch = vkey())
+        ch = vkey();
+        if (gety_ref(y_ref) != y - 2 || getx_ref(x_ref) != x)
+        {
+            /* Screen size changed and redraw is needed */
+            /* clear */
+            scr_restore_keep(&old_screen);
+            /* update position */
+            y = gety_ref(y_ref);
+            x = getx_ref(x_ref);
+            /* redraw */
+            grayout(0, b_lines, GRAYOUT_DARK);
+            max = draw_menu(y, x, title, desc, hotkey, &SINKVAL(int));
+            /* update parameters */
+            y += 2;
+            old_cur = cur;
+        }
+
+        switch (ch)
         {
         case KEY_LEFT:
         case KEY_ESC:

--- a/maple/xchatd.c
+++ b/maple/xchatd.c
@@ -3522,7 +3522,7 @@ main(
             char buf[32];
             static int xxx;
 
-            if ((++xxx & 8191) == 0)
+            if ((++xxx % 0x2000U) == 0)
             {
                 sprintf(buf, "%d/%d", nfds, maxfds);
                 logit("MAIN", buf);

--- a/maple/xover.c
+++ b/maple/xover.c
@@ -2227,7 +2227,7 @@ every_Z(void)
     if (cuser.ufo2 & UFO2_ORIGUI)
         every_Z_Orig();
     else
-        popupmenu(menu_everyz, NULL, b_lines/2U - 4, d_cols/2U + 20);
+        popupmenu(menu_everyz, NULL, B_LINES_REF/2U - 4, D_COLS_REF/2U + 20);
 
     memcpy(&(xz[XZ_OTHER - XO_ZONE]), &xy, sizeof(XZ));
 

--- a/maple/xover.c
+++ b/maple/xover.c
@@ -354,7 +354,7 @@ Tagger(
 
     for (head = 0, tail = TagNum - 1, tagp = TagList, cmp = 1; head <= tail;)
     {
-        pos = (head + tail) / 2U;
+        pos = (head + tail) >> 1;
         cmp = tagp[pos].chrono - chrono;
         if (!cmp)
         {
@@ -656,7 +656,7 @@ deny_forward(void)
         if (level & PERM_DENYMAIL)
         {
             /*
-            if ((cuser.numemail / 16U) < (cuser.numlogins + cuser.numposts))
+            if ((cuser.numemail >> 4) < (cuser.numlogins + cuser.numposts))
             {
                 cuser.userlevel = level ^ PERM_DENYMAIL;
                 return 0;
@@ -2227,7 +2227,7 @@ every_Z(void)
     if (cuser.ufo2 & UFO2_ORIGUI)
         every_Z_Orig();
     else
-        popupmenu(menu_everyz, NULL, B_LINES_REF/2U - 4, D_COLS_REF/2U + 20);
+        popupmenu(menu_everyz, NULL, (B_LINES_REF >> 1) - 4, (D_COLS_REF >> 1) + 20);
 
     memcpy(&(xz[XZ_OTHER - XO_ZONE]), &xy, sizeof(XZ));
 

--- a/so/mailgem.c
+++ b/so/mailgem.c
@@ -406,7 +406,7 @@ int num)
     {
         if (MailGemBufferSiz < num)
         {
-            num += (num / 2U);
+            num += (num >> 1);
             MailGemBufferSiz = num;
             MailGemBuffer = gbuf = (HDR *) realloc(gbuf, sizeof(HDR) * num);
         }
@@ -1171,7 +1171,7 @@ const char *fname)
 
                 if (xhead >= xsize)
                 {
-                    xsize += (xsize / 2U);
+                    xsize += (xsize >> 1);
                     xpool = (SyncData *) realloc(xpool, xsize * sizeof(SyncData));
                 }
 

--- a/so/pip.c
+++ b/so/pip.c
@@ -346,7 +346,7 @@ int mode)
         clear();
         vs_head("電子養小雞", BoardName);
         show_die_pic(2);
-        move(14, d_cols/2U + 20);
+        move(14, (d_cols>>1) + 20);
         prints("可憐的小雞\x1b[1;31m%s\x1b[m", msg);
         vmsg(NICKNAME "哀悼中....");
     }
@@ -3445,13 +3445,13 @@ static int pip_play_outing(void)       /*郊遊*/
             clear();
             prints("\x1b[1;41m  " NICKNAME PIPNAME " ～ %-10s                                                  \x1b[0m", d.name);
             show_play_pic(0);
-            move(b_lines - 6, d_cols/2U + 10);
+            move(b_lines - 6, (d_cols>>1) + 10);
             prints("\x1b[1;36m親愛的 \x1b[1;33m%s ～\x1b[0m", d.name);
-            move(b_lines - 5, d_cols/2U + 10);
+            move(b_lines - 5, (d_cols>>1) + 10);
             outs("\x1b[1;37m看到你這樣努力的培養自己的能力  讓我心中十分的高興喔..\x1b[m");
-            move(b_lines - 4, d_cols/2U + 10);
+            move(b_lines - 4, (d_cols>>1) + 10);
             outs("\x1b[1;36m小天使我決定給你獎賞鼓勵鼓勵  偷偷地幫助你一下....^_^\x1b[0m");
-            move(b_lines - 3, d_cols/2U + 10);
+            move(b_lines - 3, (d_cols>>1) + 10);
             lucky = random() % 7;
             if (lucky >= 6)
             {
@@ -5051,45 +5051,45 @@ pip_ending_screen(void)
     int endmode = 0;
     clear();
     pip_ending_decide(endbuf1, endbuf2, endbuf3, &endmode, &endgrade);
-    move(1, d_cols/2U + 9);
+    move(1, (d_cols>>1) + 9);
     outs("\x1b[1;33m╔═══╗╔══╮╗╔═══╮╔═══╗╔══╮╗╭═══╮\x1b[0m");
-    move(2, d_cols/2U + 9);
+    move(2, (d_cols>>1) + 9);
     outs("\x1b[1;37m║      ║║    ║║║      ║║      ║║    ║║║      ║\x1b[0m");
-    move(3, d_cols/2U + 9);
+    move(3, (d_cols>>1) + 9);
     outs("\x1b[0;37m║    ═╣║    ║║║  ╭╮║╚═╗╔╝║    ║║║  ╔═╗\x1b[0m");
-    move(4, d_cols/2U + 9);
+    move(4, (d_cols>>1) + 9);
     outs("\x1b[0;37m║    ═╣║  ║  ║║  ╰╯║╔═╝╚╗║  ║  ║║  ╰╯║\x1b[0m");
-    move(5, d_cols/2U + 9);
+    move(5, (d_cols>>1) + 9);
     outs("\x1b[1;37m║      ║║  ║  ║║      ║║      ║║  ║  ║║      ║\x1b[0m");
-    move(6, d_cols/2U + 9);
+    move(6, (d_cols>>1) + 9);
     outs("\x1b[1;35m╚═══╝╚═╰═╝╚═══╯╚═══╝╚═╰═╝╰═══╯\x1b[0m");
-    move(b_lines - 16, d_cols/2U + 8);
+    move(b_lines - 16, (d_cols>>1) + 8);
     outs("\x1b[1;31m──────────\x1b[41;37m " NICKNAME PIPNAME "結局報告 \x1b[0;1;31m──────────\x1b[0m");
-    move(b_lines - 14, d_cols/2U + 10);
+    move(b_lines - 14, (d_cols>>1) + 10);
     outs("\x1b[1;36m這個時間不知不覺地還是到臨了...\x1b[0m");
-    move(b_lines - 12, d_cols/2U + 10);
+    move(b_lines - 12, (d_cols>>1) + 10);
     prints("\x1b[1;37m\x1b[33m%s\x1b[37m 得離開你的溫暖懷抱，自己一隻雞在外面求生存了.....\x1b[0m", d.name);
-    move(b_lines - 10, d_cols/2U + 10);
+    move(b_lines - 10, (d_cols>>1) + 10);
     outs("\x1b[1;36m在你照顧教導他的這段時光，讓他接觸了很多領域，培養了很多的能力....\x1b[0m");
-    move(b_lines - 8, d_cols/2U + 10);
+    move(b_lines - 8, (d_cols>>1) + 10);
     prints("\x1b[1;37m因為這些，讓小雞 \x1b[33m%s\x1b[37m 之後的生活，變得更多采多姿了........\x1b[0m", d.name);
-    move(b_lines - 6, d_cols/2U + 10);
+    move(b_lines - 6, (d_cols>>1) + 10);
     outs("\x1b[1;36m對於你的關心，你的付出，你所有的愛......\x1b[0m");
-    move(b_lines - 4, d_cols/2U + 10);
+    move(b_lines - 4, (d_cols>>1) + 10);
     prints("\x1b[1;37m\x1b[33m%s\x1b[37m 會永遠都銘記在心的....\x1b[0m", d.name);
     vmsg("接下來看未來發展");
     clrchyiuan(b_lines - 16, b_lines - 4);
-    move(b_lines - 16, d_cols/2U + 8);
+    move(b_lines - 16, (d_cols>>1) + 8);
     outs("\x1b[1;34m──────────\x1b[44;37m " NICKNAME PIPNAME "未來發展 \x1b[0;1;34m──────────\x1b[0m");
-    move(b_lines - 14, d_cols/2U + 10);
+    move(b_lines - 14, (d_cols>>1) + 10);
     prints("\x1b[1;36m透過水晶球，讓我們一起來看 \x1b[33m%s\x1b[36m 的未來發展吧.....\x1b[0m", d.name);
-    move(b_lines - 12, d_cols/2U + 10);
+    move(b_lines - 12, (d_cols>>1) + 10);
     prints("\x1b[1;37m小雞 \x1b[33m%s\x1b[37m 後來%s....\x1b[0m", d.name, endbuf1);
-    move(b_lines - 10, d_cols/2U + 10);
+    move(b_lines - 10, (d_cols>>1) + 10);
     prints("\x1b[1;36m因為他的之前的努力，使得他在這一方面%s....\x1b[0m", endbuf2);
-    move(b_lines - 8, d_cols/2U + 10);
+    move(b_lines - 8, (d_cols>>1) + 10);
     prints("\x1b[1;37m至於小雞的婚姻狀況，他後來%s，婚姻算是很美滿.....\x1b[0m", endbuf3);
-    move(b_lines - 6, d_cols/2U + 10);
+    move(b_lines - 6, (d_cols>>1) + 10);
     outs("\x1b[1;36m嗯..這是一個不錯的結局唷..........\x1b[0m");
     vmsg("我想  你一定很感動吧.....");
     show_ending_pic(0);
@@ -6140,11 +6140,11 @@ int endgrade)
     gradebasic = (d.body[BODY_MAXHP] + d.body[BODY_WRIST] + d.learn[LEARN_WISDOM] + d.learn[LEARN_CHARACTER] + d.learn[LEARN_CHARM] + d.learn[LEARN_ETHICS] + d.state[STATE_BELIEF] + d.state[STATE_AFFECT]) / 10 - d.state[STATE_OFFENSE];
     clrchyiuan(1, b_lines);
     gradeall = gradebasic + endgrade;
-    move(8, d_cols/2U + 17);
+    move(8, (d_cols>>1) + 17);
     outs("\x1b[1;36m感謝您玩完整個" NICKNAME "小雞的遊戲.....\x1b[0m");
-    move(10, d_cols/2U + 17);
+    move(10, (d_cols>>1) + 17);
     outs("\x1b[1;37m經過系統計算的結果：\x1b[0m");
-    move(12, d_cols/2U + 17);
+    move(12, (d_cols>>1) + 17);
     prints("\x1b[1;36m您的小雞 \x1b[37m%s \x1b[36m總得分＝ \x1b[1;5;33m%ld \x1b[0m", d.name, gradeall);
     return gradeall;
 }
@@ -6166,11 +6166,11 @@ static int pip_divine(void) /*占卜師來訪*/
     move(b_lines - 2, 0);
     money = 300 * (tm + 1);
     clrchyiuan(6, b_lines - 6);
-    move(10, d_cols/2U + 14);
+    move(10, (d_cols>>1) + 14);
     outs("\x1b[1;33;5m叩叩叩...\x1b[0;1;37m突然傳來陣陣的敲門聲.........\x1b[0m");
     vmsg("去瞧瞧是誰吧......");
     clrchyiuan(6, b_lines - 6);
-    move(10, d_cols/2U + 14);
+    move(10, (d_cols>>1) + 14);
     outs("\x1b[1;37;46m    原來是雲遊四海的占卜師來訪了.......    \x1b[0m");
     vmsg("開門讓他進來吧....");
     if (d.thing[THING_MONEY] >= money)
@@ -6193,9 +6193,9 @@ static int pip_divine(void) /*占卜師來訪*/
                 sprintf(buf, "\x1b[1;37m  你的小雞%s以後可能的身份是%s  \x1b[m", d.name, endbuf1);
             d.thing[THING_MONEY] -= money;
             clrchyiuan(6, b_lines - 6);
-            move(10, d_cols/2U + 14);
+            move(10, (d_cols>>1) + 14);
             outs("\x1b[1;33m在我占卜結果看來....\x1b[m");
-            move(12, d_cols/2U + 14);
+            move(12, (d_cols>>1) + 14);
             outs(buf);
             vmsg("謝謝惠顧，有緣再見面了.(不準不能怪我喔)");
         }
@@ -6354,7 +6354,7 @@ const char *userid)
         else if (ck.death == 1)
         {
             show_die_pic(2);
-            move(14, d_cols/2U + 20);
+            move(14, (d_cols>>1) + 20);
             outs("可憐的小雞嗚呼哀哉了");
         }
         else if (ck.death == 2)
@@ -7729,7 +7729,7 @@ static int pip_results_show(void)  /*收穫季*/
     int a, b[3][2], c[3] = {0, 0, 0};
 
     clear();
-    move(10, d_cols/2U + 14);
+    move(10, (d_cols>>1) + 14);
     outs("\x1b[1;33m叮咚叮咚～ 辛苦的郵差幫我們送信來了喔...\x1b[0m");
     vmsg("嗯  把信打開看看吧...");
     clear();
@@ -7947,15 +7947,15 @@ int winorlost, int mode, int a, int b, int c)
         strcpy(name4, d.name);
     }
     clear();
-    move(6, d_cols/2U + 13);
+    move(6, (d_cols>>1) + 13);
     prints("\x1b[1;37m～～～ \x1b[32m本屆 %s 結果揭曉 \x1b[37m～～～\x1b[0m", gamename[mode]);
-    move(8, d_cols/2U + 15);
+    move(8, (d_cols>>1) + 15);
     prints("\x1b[1;41m 冠軍 \x1b[0;1m～ \x1b[1;33m%-10s\x1b[36m  獎金 %d\x1b[0m", name1, resultmoney[3]);
-    move(10, d_cols/2U + 15);
+    move(10, (d_cols>>1) + 15);
     prints("\x1b[1;41m 亞軍 \x1b[0;1m～ \x1b[1;33m%-10s\x1b[36m  獎金 %d\x1b[0m", name2, resultmoney[2]);
-    move(12, d_cols/2U + 15);
+    move(12, (d_cols>>1) + 15);
     prints("\x1b[1;41m 季軍 \x1b[0;1m～ \x1b[1;33m%-10s\x1b[36m  獎金 %d\x1b[0m", name3, resultmoney[1]);
-    move(14, d_cols/2U + 15);
+    move(14, (d_cols>>1) + 15);
     prints("\x1b[1;41m 最後 \x1b[0;1m～ \x1b[1;33m%-10s\x1b[36m \x1b[0m", name4);
     sprintf(buf, "今年的%s結束囉 後年再來吧..", gamename[mode]);
     d.thing[THING_MONEY] += resultmoney[winorlost];

--- a/so/pipfun.c
+++ b/so/pipfun.c
@@ -15,7 +15,7 @@ int i, int j)
 static inline void
 outs_centered(const char *str)
 {
-    prints("%*s", d_cols/2U, "");
+    prints("%*s", d_cols>>1, "");
     outs(str);
 }
 
@@ -26,7 +26,7 @@ prints_centered(const char *fmt, ...)
     char buf[512], *str;
     int cc;
 
-    prints("%*s", d_cols/2U, "");
+    prints("%*s", d_cols>>1, "");
 
     va_start(args, fmt);
     vsprintf(buf, fmt, args);
@@ -40,12 +40,12 @@ show_file(const char *filename, int y, int lines, int mode)
 {
     FILE *fp;
     clrchyiuan(y, y + lines);
-    move(y, d_cols/2U);
+    move(y, d_cols>>1);
     if ((fp = fopen(filename, "r")))
     {
         char buf[256];
         while (fgets(buf, 256, fp) && lines--) {
-            move(++y, d_cols/2U);
+            move(++y, d_cols>>1);
             outs(buf);
         }
         fclose(fp);

--- a/so/pnote.c
+++ b/so/pnote.c
@@ -92,9 +92,9 @@ rebuild_pnote_ansi(int newflag)
         sprintf(buf, "\x1b[1;33m¡¼ùù \x1b[32m%s\x1b[37m(%s)",
                 myitem.userid, myitem.username);
         len = strlen(buf);
-        strcat(buf, & " \x1b[33m"[len % 2U]);
+        strcat(buf, & " \x1b[33m"[len & 1]);
 
-        for (i = len / 2U; i < 36; i++)
+        for (i = len >> 1; i < 36; i++)
             strcat(buf, "ùù");
         sprintf(buf2, "ùù\x1b[32m %.14s \x1b[33mùù¡¼\x1b[m\n",
                 Cdate(&(myitem.date)));
@@ -180,9 +180,9 @@ do_pnote(const char *userid)
         sprintf(buf, "\x1b[1;33m¡¼ùù \x1b[32m%s\x1b[37m(%s)",
                 myitem.userid, myitem.username);
         len = strlen(buf);
-        strcat(buf, & " \x1b[33m"[len % 2U]);
+        strcat(buf, & " \x1b[33m"[len & 1]);
 
-        for (i = len / 2U; i < 36; i++)
+        for (i = len >> 1; i < 36; i++)
             strcat(buf, "ùù");
         sprintf(buf2, "ùù\x1b[32m %.14s \x1b[33mùù¡¼\x1b[m\n",
                 Cdate(&(myitem.date)));
@@ -213,7 +213,7 @@ show_pnote(notedata *pitem)
     prints_centered("\x1b[1;36m¢z¢w¢w¢w \x1b[37m%s(%s)¦b \x1b[33m%s\x1b[37m ¯dªº¸Ü \x1b[m", pitem->userid, pitem->username,
             Cdate(&(pitem->date)));
     prints("\n\x1b[1;37m%*s  %s\n%*s  %s\n%*s  %s\n\x1b[0m",
-           d_cols/2U, "", pitem->buf[0], d_cols/2U, "", pitem->buf[1], d_cols/2U, "", pitem->buf[2]);
+           d_cols>>1, "", pitem->buf[0], d_cols>>1, "", pitem->buf[1], d_cols>>1, "", pitem->buf[2]);
     outs_centered("                 \x1b[1;36m¢w¢w¢w¢w¢w¢w¢w¢w¢w¢w¢w¢w¢w¢w¢w¢w¢w¢w¢w¢w¢w¢w¢w¢w¢w¢w¢w¢w¢w¢w¢}\x1b[m\n");
     pitem->mode = 1;
 }

--- a/so/vote.c
+++ b/so/vote.c
@@ -413,7 +413,7 @@ vitem_t vlist[])
         for (;;)
         {
             buf[0] = radix32[item];
-            if (!vget((item % 16U) + 3, (item / 16U) * 40,
+            if (!vget((item % 16U) + 3, (item / 16) * 40,
                       buf, vlist[item], sizeof(vitem_t), GCARRY) || (++item >= MAX_CHOICES))
                 break;
         }

--- a/util/expire.c
+++ b/util/expire.c
@@ -112,7 +112,7 @@ sync_init(
 
                 if (xhead >= xsize)
                 {
-                    xsize += (xsize / 2U);
+                    xsize += (xsize >> 1);
                     xpool = (SyncData *) realloc(xpool, xsize * sizeof(SyncData));
                 }
 

--- a/util/gem-check.c
+++ b/util/gem-check.c
@@ -126,7 +126,7 @@ sync_init(
 
                 if (xhead >= xsize)
                 {
-                    xsize += (xsize / 2U);
+                    xsize += (xsize >> 1);
                     xpool = (SyncData *) realloc(xpool, xsize * sizeof(SyncData));
                 }
 
@@ -280,7 +280,7 @@ sync_check(
         {
             xsync->exotic = 0;
             cc = xsync->chrono;
-            *str = radix32[cc % 32];
+            *str = radix32[cc % 32U];
             archiv32m(cc, fname);
             fname[0] = xsync->prefix;
 
@@ -350,7 +350,7 @@ check_log(
         fpw = NULL;
         if (!fstat(fileno(fpr), &st) && st.st_size > 32768)
         {
-            fseek(fpr, st.st_size / 2U, 0);
+            fseek(fpr, st.st_size >> 1, 0);
 
             while (fgets(buf, sizeof(buf), fpr))
             {

--- a/util/reaper.c
+++ b/util/reaper.c
@@ -233,7 +233,7 @@ eaddr_group(
             break;
         }
 
-        mid = (left + right) / 2U;
+        mid = (left + right) >> 1;
         cptr = &chain[mid];
         cmp = hash - cptr->hash;
 

--- a/util/redir.c
+++ b/util/redir.c
@@ -43,7 +43,7 @@ pool_add(
 
     if (n_head >= n_size)
     {
-        n_size += (n_size / 2U);
+        n_size += (n_size >> 1);
         n_pool = (FNAME *) realloc(n_pool, n_size * sizeof(FNAME));
     }
 

--- a/util/remboxdir.c
+++ b/util/remboxdir.c
@@ -43,7 +43,7 @@ pool_add(
 
     if (n_head >= n_size)
     {
-        n_size += (n_size / 2U);
+        n_size += (n_size >> 1);
         n_pool = (FNAME *) realloc(n_pool, n_size * sizeof(FNAME));
     }
 

--- a/util/utmp-dump.c
+++ b/util/utmp-dump.c
@@ -96,7 +96,7 @@ can_see(
     {
         for (count = up->pal_max; count > 0;)
         {
-            datum = cache[mid = count / 2U];
+            datum = cache[mid = count >> 1];
             if ((-cuser.userno) == datum)
                 return 2;
             if ((-cuser.userno) > datum)
@@ -114,7 +114,7 @@ can_see(
     {
         for (count = up->pal_max; count > 0;)
         {
-            datum = cache[mid = count / 2U];
+            datum = cache[mid = count >> 1];
             if (cuser.userno == datum)
                 return 1;
             if (cuser.userno > datum)
@@ -143,7 +143,7 @@ is_bad(
     {
         for (count = pal_count; count > 0;)
         {
-            datum = cache[mid = count / 2U];
+            datum = cache[mid = count >> 1];
             if ((-userno) == datum)
                 return true;
             if ((-userno) > datum)
@@ -231,7 +231,7 @@ is_pal(
     {
         for (count = pal_count; count > 0;)
         {
-            datum = cache[mid = count / 2U];
+            datum = cache[mid = count >> 1];
             if (userno == datum)
                 return true;
             if (userno > datum)


### PR DESCRIPTION
# Fix Pack 005b Change Log (en-US)

## Fixes relevant to user experience
- Fix and resume the use of the screen size–referencing coordination mapping. The issue that `popupmenu_ans2` behaved weirdly is fixed.
- Fix the layout of the title bar broken due to unsigned operation
- Fix the cursor clears the ten thousand digit of the item number in xover list
- Fix undefining `DL_HOTSWAP` enables hotswapping for xover list
- Fix the implementation of hotswapping mechanism of xover list causes segmentation faults

## Other fixes
- Avoid unsigned division. Change bitwise AND into unsigned modulo if appropriate.

# Fix Pack 005b Change Log (zh-TW)

## 與使用者體驗有關的修正
- 修正並恢復畫面大小參考座標系統的使用，修正 `popupmenu_ans2` 不正常運作的問題
- 修正因無號運算問題導致標題列跑版的問題
- 修正畫游標時會消去 xover 列表編號萬位數的問題
- 修正未定義 `DL_HOTSWAP` 時反而啟用 xover 列表的 hotswapping 機制的問題
- 修正 xover 列表的 hotswapping 機制的實作會導致 segmentation fault 的問題

## 其他修正
- 避免使用無號除法，並視情況將位元 AND 運算改為無號取餘數