### PR TITLE
Fix Pack 005c: System Evaporation

### DIFF
--- a/include/config.h
+++ b/include/config.h
@@ -528,9 +528,6 @@
 #define MENU_YPOS       13
 #define MENU_XPOS_REF   ((D_COLS_REF >> 1) + 23)  /* For `get[y|x]_ref()` & `move_ref()` */
 #define MENU_YPOS_REF   13
-#define MENU_LOAD       1
-#define MENU_DRAW       2
-#define MENU_FILM       4
 
 /* ----------------------------------------------------- */
 /* 系統參數                                              */

--- a/include/dao.h
+++ b/include/dao.h
@@ -177,6 +177,7 @@ int xwrite(int fd, const char *data, int size);
 #endif
 
 /* `proc_runl` without the need of `arg0` and trailing `NULL` */
+/* Use `PROC_CMD(path, NULL)` when no other arguments are needed */
 #define PROC_CMD(path, ...) proc_runl(path, path, __VA_ARGS__, NULL)
 
 #endif  /* DAO_H */

--- a/include/dao.h
+++ b/include/dao.h
@@ -169,6 +169,8 @@ char *Now(void);
 /* proc.c */
 int proc_runv(const char *path, const char *argv[]);
 GCC_CHECK_SENTINEL(0) int proc_runl(const char *path, const char *arg0, ...);
+int proc_runv_bg(const char *path, const char *argv[]);
+GCC_CHECK_SENTINEL(0) int proc_runl_bg(const char *path, const char *arg0, ...);
 /* xwrite.c */
 int xwrite(int fd, const char *data, int size);
 
@@ -179,5 +181,9 @@ int xwrite(int fd, const char *data, int size);
 /* `proc_runl` without the need of `arg0` and trailing `NULL` */
 /* Use `PROC_CMD(path, NULL)` when no other arguments are needed */
 #define PROC_CMD(path, ...) proc_runl(path, path, __VA_ARGS__, NULL)
+
+/* `proc_runl_bg` without the need of `arg0` and trailing `NULL` */
+/* Use `PROC_CMD_BG(path, NULL)` when no other arguments are needed */
+#define PROC_CMD_BG(path, ...) proc_runl_bg(path, path, __VA_ARGS__, NULL)
 
 #endif  /* DAO_H */

--- a/include/dao.h
+++ b/include/dao.h
@@ -166,11 +166,17 @@ char *Ctime(const time_t *clock);
 char *Etime(const time_t *clock);
 char *Atime(const time_t *clock);
 char *Now(void);
+/* proc.c */
+int proc_runv(const char *path, const char *argv[]);
+GCC_CHECK_SENTINEL(0) int proc_runl(const char *path, const char *arg0, ...);
 /* xwrite.c */
 int xwrite(int fd, const char *data, int size);
 
 #ifdef __cplusplus
 }  /* extern "C" */
 #endif
+
+/* `proc_runl` without the need of `arg0` and trailing `NULL` */
+#define PROC_CMD(path, ...) proc_runl(path, path, __VA_ARGS__, NULL)
 
 #endif  /* DAO_H */

--- a/include/dns.h
+++ b/include/dns.h
@@ -38,7 +38,7 @@ typedef union
     struct sockaddr_in6 v6;
 }     ip_addr;  /* SHMDATA(raw); dependency(UTMP) */
 
-#define IPADDR_NONE     TEMPLVAL(ip_addr, {0})
+#define IPADDR_NONE     LISTLIT(ip_addr){0}
 
 /*
  * The standard udp packet size PACKETSZ (512) is not sufficient for some

--- a/include/global.h
+++ b/include/global.h
@@ -329,6 +329,8 @@
 #define I_TIMEOUT       0x04FD
 #define I_OTHERDATA     0x04FE
 
+#define I_RESIZETERM    Meta(Ctrl('L'))
+
 #define KEY_NONE        0x4000  /* All key values should `< KEY_NONE` */
 
 #define Ctrl(c)         ( c & ~0x0060 )

--- a/include/modes.h
+++ b/include/modes.h
@@ -244,6 +244,12 @@ static const char *const ModeTypeTable[] =
 #define XO_LAST         ((XZ_ZONE | XZ_BACK) + XO_NONE)
 #define XO_QUIT         ((XZ_ZONE | XZ_QUIT) + XO_NONE)
 
+/* Miscellaneous commands ({XO_WRAP|XO_SCRL|XO_REL} + key; key <= KEY_NONE) */
+#define XO_CUR          (XO_REL + XO_CUR_BIAS)  /* Redraw the item under the cursor and do relative move */
+#define XO_CUR_BIAS     0x2000               /* Bias of relative move */
+#define XO_CUR_MIN      (XO_REL + 0)         /* The minimum value of relative move */
+#define XO_CUR_MAX      (XO_REL + KEY_NONE)  /* The maximum value of relative move */
+
 /* Special values */
 
 //#define XO_RSIZ         256             /* max record length */ /* IID.20200102: Unlimited. */

--- a/include/modes.h
+++ b/include/modes.h
@@ -139,9 +139,9 @@ static const char *const ModeTypeTable[] =
 /* ----------------------------------------------------- */
 
 
-#define XEASY   0x333           /* Return value to un-redraw screen */
-#define QUIT    0x666           /* Return value to abort recursive functions */
-#define SKIN    0x999           /* Return value to change skin */
+#define XEASY   XO_FOOT         /* Return value to un-redraw screen */
+#define QUIT    XO_QUIT         /* Return value to abort recursive functions */
+#define SKIN    XO_SKIN         /* Return value to change skin */
 
 
 /* ----------------------------------------------------- */
@@ -278,10 +278,12 @@ static const char *const ModeTypeTable[] =
 #define XZ_FINI         0x02000000      /* Perform finalization tasks for a zone */
 #define XZ_BACK         0x04000000      /* Return to the last zone */
 #define XZ_QUIT         0x08000000      /* Exit `xover()` */
-#define XZ_UNUSED4      0x10000000
+#define XZ_SKIN         0x10000000      /* Change the skin instead of the zone */
+
 #define XZ_UNUSED5      0x20000000
 
 #define XO_ZONE         (XZ_ZONE + XO_MOVE)
+#define XO_SKIN         ((XZ_ZONE | XZ_SKIN) + XO_MOVE)
 
 /* Zone indexes */
 

--- a/include/modes.h
+++ b/include/modes.h
@@ -10,6 +10,8 @@
 #ifndef MODES_H
 #define MODES_H
 
+#include "perm.h"
+
 enum
 {STRIP_ALL, ONLY_COLOR, NO_RELOAD};
 
@@ -21,15 +23,8 @@ enum
 /* user 操作狀態與模式                                   */
 /* ----------------------------------------------------- */
 
-#if NO_SO
-#define M_DL(umode)     (umode)
-#else
-#define M_DL(umode)     (-(umode))  /* For dynamic library loading */
-#endif
-
-#define M_ARG           0x40000000  /* `item` is a function and a `void *` argument */
-
-#define M_MASK          0x0000FFFF  /* Mask for valid user modes */
+#define M_MENU          M_MMENU     /* The first menu mode */
+#define M_FUN           M_PROFESS   /* The first non-menu, non-idle mode */
 
 #define M_IDLE          0
 #define M_MMENU         1       /* menu mode */
@@ -135,9 +130,32 @@ static const char *const ModeTypeTable[] =
 
 
 /* ----------------------------------------------------- */
-/* menu.c 中的模式                                       */
+/* menu.c & popupmenu.c 中的模式                         */
 /* ----------------------------------------------------- */
 
+/* For `umode` */
+
+#if NO_SO
+#define M_DL(umode)     (umode)
+#else
+#define M_DL(umode)     ((umode) | 0x80000000)  /* For dynamic library loading */
+#endif
+
+#define M_QUIT          0x01000000  /* Return to the outer menu after selection */
+#define M_XO            0x02000000  /* `item` is a xover function */
+#define M_ARG           0x04000000  /* `item` is a function and a `void *` argument */
+
+#define M_DOINSTANT     0x00010000  /* Immidiately select a menu item after command match */
+#define M_MENUTITLE     0x00020000  /* `item` is a string for the menu title */
+#define M_TAIL_MASK     0x00FF0000  /* Mask for the flags which indicate the menu list tail */
+
+#define M_MASK          0x0000FFFF  /* Mask for valid user modes */
+
+/* For `level` */
+
+#define PERM_MENU       PERM_PURGE  /* A permission flag reserved for valid users */
+
+/* Traditional return values */
 
 #define XEASY   XO_FOOT         /* Return value to un-redraw screen */
 #define QUIT    XO_QUIT         /* Return value to abort recursive functions */

--- a/include/popup.h
+++ b/include/popup.h
@@ -10,21 +10,19 @@
 #ifndef POPUP_H
 #define POPUP_H
 
-#define POPUP_QUIT              0x00
-#define POPUP_FUN               0x01
-#define POPUP_XO                0x02
-#define POPUP_MENU              0x04
-#define POPUP_MENUTITLE         0x08
+#include "modes.h"
+
+#define POPUP_QUIT              M_QUIT
+#define POPUP_FUN               M_FUN
+#define POPUP_XO                (M_FUN | M_XO)
+#define POPUP_MENU              M_MENU
+#define POPUP_MENUTITLE         (M_MENU | M_MENUTITLE)
 #if NO_SO
-  #define POPUP_SO              POPUP_FUN
+  #define POPUP_SO              M_FUN
 #else
-  #define POPUP_SO              0x10  /* For dynamic library loading */
+  #define POPUP_SO              M_DL(M_FUN) /* For dynamic library loading */
 #endif
 
-#define POPUP_DO_INSTANT        0x01000000
-
-#define POPUP_ARG               0x40000000  /* `item` is a function and a `void *` argument */
-
-#define POPUP_MASK              0x000000FF
+#define POPUP_ARG               M_ARG  /* `item` is a function and a `void *` argument */
 
 #endif  /* #ifndef POPUP_H */

--- a/include/proto.h
+++ b/include/proto.h
@@ -344,6 +344,8 @@ int xo_cb_foot(XO *xo);
 int xo_cb_last(XO *xo);
 int xo_cb_quit(XO *xo);
 void xover(int cmd);
+int xover_exec_cb(XO *xo, int cmd);
+int xover_key(XO *xo, int zone, int cmd);
 void every_Z(void);
 void every_U(void);
 void every_B(void);

--- a/include/proto.h
+++ b/include/proto.h
@@ -173,6 +173,7 @@ void vs_mid(const char *mid);
 void vs_head(const char *title, const char *mid);
 void clear_notification(void);
 void movie(void);
+GCC_PURE int strip_ansi_n_len(const char *str, int maxlen);
 GCC_PURE int strip_ansi_len(const char *str);
 const char *check_info(const char *input);
 void main_menu(void);

--- a/include/proto.h
+++ b/include/proto.h
@@ -89,6 +89,7 @@ int Ben_Perm(const BRD *bhdr, unsigned int ulevel);
 GCC_PURE int bstamp2bno(time_t stamp);
 void brh_load(void);
 void brh_save(void);
+bool XoPostSimple(int bno);
 bool XoPost(int bno);
 void board_outs(int chn, int num);
 void class_outs(const char *title, int num);

--- a/include/proto.h
+++ b/include/proto.h
@@ -346,7 +346,7 @@ int xo_cb_quit(XO *xo);
 void xover(int cmd);
 int xover_exec_cb(XO *xo, int cmd);
 int xover_key(XO *xo, int zone, int cmd);
-void every_Z(void);
+void every_Z(XO *xo);
 void every_U(void);
 void every_B(void);
 void every_S(void);

--- a/include/proto.h
+++ b/include/proto.h
@@ -313,6 +313,7 @@ void grayoutrect(int y, int yend, int x, int xend, int level);
 void grayout(int y, int end, int level);
 #endif  /* #ifndef M3_USE_PFTERM */
 void add_io(int fd, int timeout);
+int iac_process(const unsigned char *current, const unsigned char *end, int *pcount);
 int iac_count(const unsigned char *current);
 int igetch(void);
 BRD *ask_board(char *board, unsigned int perm, const char *msg);

--- a/include/proto.h
+++ b/include/proto.h
@@ -75,6 +75,7 @@ void brd_edit(int bno);
 int a_editbrd(void);
 int u_verify(void);
 /* bbsd.c */
+void blog_pid(const char *mode, const char *msg, pid_t pid);
 void blog(const char *mode, const char *msg);
 void u_exit(const char *mode);
 GCC_NORETURN void abort_bbs(void);

--- a/include/struct.h
+++ b/include/struct.h
@@ -1111,7 +1111,7 @@ typedef struct {
 
 typedef union {  /* The field to be used is determined by the value of `umode` */
     int (*func) (void);  /* Default (menu) or `POPUP_FUN` (popupmenu) */
-    FuncArg funcarg;  /* `umode | M_ARG` (menu) or `umode | POPUP_FUN` (popupmenu) */
+    FuncArg funcarg;  /* `umode | M_ARG` (menu) or `POPUP_FUN | POPUP_ARG` (popupmenu) */
 
     int (*xofunc) (XO *xo);  /* `POPUP_XO` (popupmenu) */
 
@@ -1121,7 +1121,7 @@ typedef union {  /* The field to be used is determined by the value of `umode` *
 #else
     const char *dlfunc;
 #endif
-    DlFuncArg dlfuncarg;  /* `M_DL(umode | M_ARG)` (menu) or `POPUP_SO | POPUP_ARG)` (popupmenu) */
+    DlFuncArg dlfuncarg;  /* `M_DL(umode | M_ARG)` (menu) or `M_DL(POPUP_FUN | POPUP_ARG)` or `POPUP_SO | POPUP_ARG` (popupmenu) */
 
     const char *title;  /* `POPUP_MENUTITLE` (popupmenu) */
     struct MENU *menu;  /* `<= M_XMENU` (menu) or `POPUP_MENU` (popupmenu) */

--- a/include/struct.h
+++ b/include/struct.h
@@ -1109,19 +1109,24 @@ typedef struct {
     const void *arg;
 } DlFuncArg;
 
-typedef union {  /* The field to be used is determined by the value of `umode` */
+typedef union {
+    /* The field to be used is determined by the value of `umode` */
+#if NO_SO
+    int (*func) (void);  /* `M_DL(umode)` (menu & popupmenu) or `POPUP_SO` (popupmenu) */
+#else
+    const char *func;
+#endif
+} DlMenuItem;
+
+typedef union {
+    /* The field to be used is determined by the value of `umode` */
     int (*func) (void);  /* Default (menu) or `POPUP_FUN` (popupmenu) */
     FuncArg funcarg;  /* `umode | M_ARG` (menu) or `POPUP_FUN | POPUP_ARG` (popupmenu) */
 
     int (*xofunc) (XO *xo);  /* `POPUP_XO` (popupmenu) */
 
-
-#if NO_SO
-    int (*dlfunc) (void);  /* `M_DL(umode)` (menu & popupmenu) or `POPUP_SO` (popupmenu) */
-#else
-    const char *dlfunc;
-#endif
-    DlFuncArg dlfuncarg;  /* `M_DL(umode | M_ARG)` (menu) or `M_DL(POPUP_FUN | POPUP_ARG)` or `POPUP_SO | POPUP_ARG` (popupmenu) */
+    DlMenuItem dl;  /* `M_DL(umode)` (menu & popupmenu) or `POPUP_SO` (popupmenu) */
+    DlFuncArg dlfuncarg;  /* `M_DL(umode | M_ARG)` (menu & popupmenu) or `POPUP_FUN | POPUP_ARG` (popupmenu) */
 
     const char *title;  /* `POPUP_MENUTITLE` (popupmenu) */
     struct MENU *menu;  /* `<= M_XMENU` (menu) or `POPUP_MENU` (popupmenu) */

--- a/include/struct.h
+++ b/include/struct.h
@@ -1096,47 +1096,59 @@ typedef struct PostRecommendHistory
 #endif  /* #if 0 */
 
 typedef struct {
-    int (*func)(const void *arg);
+    union {
+        int (*func)(const void *arg);
+        int (*xofunc)(XO *xo, const void *arg);
+    };
     const void *arg;
 } FuncArg;
 
 typedef struct {
+    union {
 #if NO_SO
-    int (*func)(const void *arg);
+        int (*func)(const void *arg);
+        int (*xofunc)(XO *xo, const void *arg);
 #else
-    const char *func;
+        const char *func;
+        const char *xofunc;
 #endif
+    };
     const void *arg;
 } DlFuncArg;
 
 typedef union {
     /* The field to be used is determined by the value of `umode` */
 #if NO_SO
-    int (*func) (void);  /* `M_DL(umode)` (menu & popupmenu) or `POPUP_SO` (popupmenu) */
+    int (*func) (void);  /* `M_DL(umode)`, `umode` `>= M_FUN` or `M_IDLE` */
+    int (*xofunc) (XO *xo);  /* `M_DL(umode | M_XO)` */
+    const char *title;  /* `M_DL(umode | M_MENUTITLE)` */
+    struct MENU *menu;  /* `M_DL(umode)`, `umode` `>= M_MENU` and `< M_FUN` */
 #else
     const char *func;
+    const char *xofunc;
+    const char *title;
+    const char *menu;
 #endif
 } DlMenuItem;
 
 typedef union {
     /* The field to be used is determined by the value of `umode` */
-    int (*func) (void);  /* Default (menu) or `POPUP_FUN` (popupmenu) */
-    FuncArg funcarg;  /* `umode | M_ARG` (menu) or `POPUP_FUN | POPUP_ARG` (popupmenu) */
+    int (*func) (void);  /* `>= M_FUN` or `M_IDLE` */
+    int (*xofunc) (XO *xo);  /* `umode | M_XO` */
+    FuncArg funcarg;  /* `umode | M_ARG` */
 
-    int (*xofunc) (XO *xo);  /* `POPUP_XO` (popupmenu) */
+    DlMenuItem dl;  /* `M_DL(umode)` */
+    DlFuncArg dlfuncarg;  /* `M_DL(umode) | M_ARG` */
 
-    DlMenuItem dl;  /* `M_DL(umode)` (menu & popupmenu) or `POPUP_SO` (popupmenu) */
-    DlFuncArg dlfuncarg;  /* `M_DL(umode | M_ARG)` (menu & popupmenu) or `POPUP_FUN | POPUP_ARG` (popupmenu) */
-
-    const char *title;  /* `POPUP_MENUTITLE` (popupmenu) */
-    struct MENU *menu;  /* `<= M_XMENU` (menu) or `POPUP_MENU` (popupmenu) */
+    const char *title;  /* `umode | M_MENUTITLE` */
+    struct MENU *menu;  /* `>= M_MENU` and `< M_FUN` */
 } MenuItem;
 
 typedef struct MENU
 {
     MenuItem item;
     unsigned int level;
-    int umode;
+    unsigned int umode;
     const char *desc;
 } MENU;
 

--- a/lib/CMakeLists.txt
+++ b/lib/CMakeLists.txt
@@ -12,6 +12,7 @@ add_library(dao STATIC
     acl.c       chrono32.c  file.c    isnot.c    radix32.c   shm.c
     archiv32.c  dl_lib.c    record.c  splay.c    date_str.c  xsort.c
     attr_lib.c  dns.c       header.c  rfc2047.c  string.c    xwrite.c
+    proc.c
 )
 if(CMAKE_SIZEOF_VOID_P EQUAL 8)
     target_link_libraries(dao PRIVATE -m32)

--- a/lib/Makefile
+++ b/lib/Makefile
@@ -14,11 +14,13 @@ HDR 	= dao.h dao.p
 
 SRC	= acl.c       chrono32.c  file.c    isnot.c    radix32.c   shm.c   \
 	  archiv32.c  dl_lib.c    record.c  splay.c    date_str.c  xsort.c \
-	  attr_lib.c  dns.c       header.c  rfc2047.c  string.c    xwrite.c
+	  attr_lib.c  dns.c       header.c  rfc2047.c  string.c    xwrite.c \
+	  proc.c
 
 OBJ	= acl.o       chrono32.o  file.o    isnot.o    radix32.o   shm.o   \
 	  archiv32.o  dl_lib.o    record.o  splay.o    date_str.o  xsort.o \
-	  attr_lib.o  dns.o       header.o  rfc2047.o  string.o    xwrite.o
+	  attr_lib.o  dns.o       header.o  rfc2047.o  string.o    xwrite.o \
+	  proc.o
 
 .c.o:   ;$(CC) $(CFLAGS) -c $*.c
 

--- a/lib/proc.c
+++ b/lib/proc.c
@@ -1,0 +1,78 @@
+/*-------------------------------------------------------*/
+/* lib/proc.c   ( NCKU CCNS WindTop-DreamBBS 3.0 )       */
+/*-------------------------------------------------------*/
+/* Author: 37586669+IepIweidieng@users.noreply.github.com*/
+/* Target: Process manipulation library for DreamBBS     */
+/* Create: 2020/02/24                                    */
+/*-------------------------------------------------------*/
+
+#include "config.h"
+
+#include <sys/types.h>
+#include <sys/wait.h>
+#include <unistd.h>
+#include <stdarg.h>
+#include <stdlib.h>
+#include "dao.h"
+
+/* `proc_run*()`: Run executable `path` in a child process */
+
+int proc_runv(const char *path, const char *argv[])
+{
+    const pid_t pid = fork();
+
+    switch (pid)
+    {
+    case 0:  // Children
+        execv(path, (char **)argv);
+        exit(127);  // `execv()` failed
+
+    case -1:  // Error
+        return -1;
+
+    default:
+        waitpid(pid, &SINKVAL(int), 0);
+        return 0;
+    }
+}
+
+/* Variadic version for convenience */
+GCC_CHECK_SENTINEL(0)
+int proc_runl(const char *path, const char *arg0, ...)
+{
+    /* Collect args first */
+
+    int argc = 0;
+    int argv_len = 8;
+    const char **argv = (const char **)malloc(sizeof(const char *) * argv_len);
+    const char *ptr;
+    int ret;
+
+    argv[argc++] = arg0;
+
+    if (arg0)
+    {
+        va_list args;
+        va_start(args, arg0);
+        while ((ptr = va_arg(args, const char *)))
+        {
+            argv[argc++] = ptr;
+            if (argc >= argv_len)
+            {
+                const char **argv_new = (const char **)realloc(argv, sizeof(const char *) * (argv_len *= 2));
+                if (!argv_new)
+                    return -1;  // `realloc()` failed
+                argv = argv_new;
+            }
+        }
+        va_end(args);
+
+        argv[argc++] = NULL;
+    }
+
+    /* And then invoke it */
+
+    ret = proc_runv(path, argv);
+    free(argv);
+    return ret;
+}

--- a/lib/proc.c
+++ b/lib/proc.c
@@ -17,13 +17,19 @@
 
 /* `proc_run*()`: Run executable `path` in a child process */
 
-int proc_runv(const char *path, const char *argv[])
+static int runv(bool wait, const char *path, const char *argv[])
 {
     const pid_t pid = fork();
 
     switch (pid)
     {
     case 0:  // Children
+        if (!wait)
+        {
+            /* Detach from parent */
+            setsid();
+            signal(SIGHUP, SIG_IGN);
+        }
         execv(path, (char **)argv);
         exit(127);  // `execv()` failed
 
@@ -31,14 +37,13 @@ int proc_runv(const char *path, const char *argv[])
         return -1;
 
     default:
-        waitpid(pid, &SINKVAL(int), 0);
+        if (wait)
+            waitpid(pid, &SINKVAL(int), 0);
         return 0;
     }
 }
 
-/* Variadic version for convenience */
-GCC_CHECK_SENTINEL(0)
-int proc_runl(const char *path, const char *arg0, ...)
+static int runvl(bool wait, const char *path, const char *arg0, va_list args)
 {
     /* Collect args first */
 
@@ -52,8 +57,6 @@ int proc_runl(const char *path, const char *arg0, ...)
 
     if (arg0)
     {
-        va_list args;
-        va_start(args, arg0);
         while ((ptr = va_arg(args, const char *)))
         {
             argv[argc++] = ptr;
@@ -65,14 +68,47 @@ int proc_runl(const char *path, const char *arg0, ...)
                 argv = argv_new;
             }
         }
-        va_end(args);
 
         argv[argc++] = NULL;
     }
 
     /* And then invoke it */
 
-    ret = proc_runv(path, argv);
+    ret = runv(wait, path, argv);
     free(argv);
+    return ret;
+}
+
+int proc_runv(const char *path, const char *argv[])
+{
+    return runv(true, path, argv);
+}
+
+/* Variadic version for convenience */
+GCC_CHECK_SENTINEL(0)
+int proc_runl(const char *path, const char *arg0, ...)
+{
+    int ret;
+    va_list args;
+    va_start(args, arg0);
+    ret = runvl(true, path, arg0, args);
+    va_end(args);
+    return ret;
+}
+
+/* Run in background */
+int proc_runv_bg(const char *path, const char *argv[])
+{
+    return runv(false, path, argv);
+}
+
+GCC_CHECK_SENTINEL(0)
+int proc_runl_bg(const char *path, const char *arg0, ...)
+{
+    int ret;
+    va_list args;
+    va_start(args, arg0);
+    ret = runvl(false, path, arg0, args);
+    va_end(args);
     return ret;
 }

--- a/maple/acct.c
+++ b/maple/acct.c
@@ -2860,7 +2860,7 @@ int m_register(void)
                 if (vans("確定無其他站務審核中？") == 'y')
                 {
                     system("/bin/cat run/" FN_RFORM ".tmp >> run/" FN_RFORM
-                           ";/bin/rm -f ~bbs/run/" FN_RFORM ".tmp");
+                           ";/bin/rm -f " BBSHOME "/run/" FN_RFORM ".tmp");
                     vmsg("修正完畢，下次請小心審核! 按任意鍵重新開始.");
                 }
             }

--- a/maple/acct.c
+++ b/maple/acct.c
@@ -257,13 +257,13 @@ void x_file(int mode,            /* M_XFILES / M_UFILES */
                 "%*s%s", BMAX(24 - len_strip - 4, 0), "", flist[n] + 4);
                                        /* statue.000703: 註解: +4 去掉目錄 */
         }
-        list[n] = TEMPLVAL(MENU,
-                {{.funcarg = {x_edit_file, flist[n]}}, 0, mode | M_ARG, strdup(buf)});
+        list[n] =
+            LISTLIT(MENU){{.funcarg = {x_edit_file, flist[n]}}, 0, mode | M_ARG, strdup(buf)};
         n++;
     }
     sprintf(buf, "%s\n%s", (mode == M_XFILES) ? "編系統檔案" : "編個人檔案",
             "輸入檔案編號可跳至該項；按 (Enter)(→) 確定；按 (Esc)(e)(←) 回去");
-    list[n] = TEMPLVAL(MENU, {{NULL}, PERM_MENU, mode, buf});
+    list[n] = LISTLIT(MENU){{NULL}, PERM_MENU, mode, buf};
 
     if (mode == M_UFILES)
         domenu(list, MENU_YPOS_REF, MENU_XPOS_REF, 0, 0, 1);

--- a/maple/acct.c
+++ b/maple/acct.c
@@ -235,7 +235,6 @@ static int x_edit_file(const void *arg)
     return 0;
 }
 
-#define PERM_MENU       PERM_PURGE
 void x_file(int mode,            /* M_XFILES / M_UFILES */
             const char *const xlist[], /* description list */
             const char *const flist[]  /* filename list */
@@ -258,7 +257,7 @@ void x_file(int mode,            /* M_XFILES / M_UFILES */
                                        /* statue.000703: 註解: +4 去掉目錄 */
         }
         list[n] =
-            LISTLIT(MENU){{.funcarg = {x_edit_file, flist[n]}}, 0, mode | M_ARG, strdup(buf)};
+            LISTLIT(MENU){{.funcarg = {{x_edit_file}, flist[n]}}, 0, mode | M_ARG, strdup(buf)};
         n++;
     }
     sprintf(buf, "%s\n%s", (mode == M_XFILES) ? "編系統檔案" : "編個人檔案",

--- a/maple/acct.c
+++ b/maple/acct.c
@@ -1117,12 +1117,11 @@ void acct_setup(ACCT * u, int adm)
                 break;
             case 'o':
                 {
-                    char command[256];
+                    char buf_mode[12], buf_time[22];
                     mode = select_mode(0);
-                    sprintf(command, BINARY_SUFFIX"stopperm %s %s %d %s %d &",
-                            u->userid, u->vmail, mode, cuser.userid,
-                            (int)time(0));
-                    system(command);
+                    sprintf(buf_mode, "%d", mode);
+                    sprintf(buf_time, "%lld", (long long)time(NULL));
+                    PROC_CMD_BG(BINARY_SUFFIX"stopperm", u->userid, u->vmail, buf_mode, cuser.userid, buf_time);
                 }
                 break;
             }

--- a/maple/acct.c
+++ b/maple/acct.c
@@ -2312,15 +2312,12 @@ void brd_edit(int bno)
             /* 以免造成*bname為NULL時，會砍到 gem/brd and brd。 statue.000728 */
             if (*bname)
             {
-                char cmd[256];
                 sprintf(buf, "gem/brd/%s", bname);
                 //f_rm(buf);
                 //f_rm(buf + 4);
                 /* 100721.cache: f_rm is buggy... */
-                sprintf(cmd, "rm -rf %s", buf);
-                system(cmd);
-                sprintf(cmd, "rm -rf %s", buf + 4);
-                system(cmd);
+                PROC_CMD("/bin/rm", "-rf", buf);
+                PROC_CMD("/bin/rm", "-rf", buf + 4);
                 memset(&newbh, 0, sizeof(newbh));
                 sprintf(newbh.title, "[%s] deleted by %s", bname,
                         cuser.userid);
@@ -2858,8 +2855,8 @@ int m_register(void)
                     ("\n\n\x1b[1;33m請確定沒有其他站務在審核，否則將造成\x1b[1;31;5m使用者資料嚴重錯誤!\x1b[m\n\n\n");
                 if (vans("確定無其他站務審核中？") == 'y')
                 {
-                    system("/bin/cat run/" FN_RFORM ".tmp >> run/" FN_RFORM
-                           ";/bin/rm -f " BBSHOME "/run/" FN_RFORM ".tmp");
+                    system("/bin/cat run/" FN_RFORM ".tmp >> run/" FN_RFORM);
+                    PROC_CMD("/bin/rm", "-f", BBS_HOME "/run/" FN_RFORM ".tmp");
                     vmsg("修正完畢，下次請小心審核! 按任意鍵重新開始.");
                 }
             }
@@ -2973,7 +2970,7 @@ int m_trace(void)
         case '1':
             if (otflag)
             {
-                system("/bin/touch trace");
+                PROC_CMD("/bin/touch", "trace");
                 msg = "BBS   tracing enabled.";
                 report("opened report log");
             }
@@ -2988,7 +2985,7 @@ int m_trace(void)
         case '2':
             if (ctflag)
             {
-                system("/bin/touch trace.chatd");
+                PROC_CMD("/bin/touch", "trace.chatd");
                 msg = "Chat  tracing enabled.";
                 report("chatd trace log opened");
             }
@@ -3003,7 +3000,7 @@ int m_trace(void)
         case '3':
             if (btflag)
             {
-                system("/bin/touch trace.bvote");
+                PROC_CMD("/bin/touch", "trace.bvote");
                 msg = "BVote tracing enabled.";
                 report("BVote trace log opened");
             }

--- a/maple/banmail.c
+++ b/maple/banmail.c
@@ -220,8 +220,6 @@ static int banmail_change(XO * xo)
     {
         banmail->time = time(0);
         rec_put(xo->dir, banmail, sizeof(BANMAIL), pos);
-        move(3 + cur, 0);
-        banmail_item(++pos, banmail);
         return XR_FOOT + XO_CUR;
     }
 

--- a/maple/banmail.c
+++ b/maple/banmail.c
@@ -214,7 +214,7 @@ static int banmail_change(XO * xo)
         rec_put(xo->dir, banmail, sizeof(BANMAIL), pos);
         move(3 + cur, 0);
         banmail_item(++pos, banmail);
-        cursor_show(3 + cur, 0);
+        return XR_FOOT + XO_CUR;
     }
 
     return XO_FOOT;

--- a/maple/banmail.c
+++ b/maple/banmail.c
@@ -35,6 +35,14 @@ static void banmail_item(int num, const BANMAIL * ban)
            modes, d_cols + 49, d_cols + 49, ban->data);
 }
 
+static int banmail_cur(XO *xo)
+{
+    const BANMAIL *const banmail = (const BANMAIL *) xo_pool_base + xo->pos;
+    move(3 + xo->pos - xo->top, 0);
+    banmail_item(xo->pos + 1, banmail);
+    return XO_NONE;
+}
+
 static int banmail_body(XO * xo)
 {
     const BANMAIL *banmail = NULL;
@@ -232,6 +240,7 @@ KeyFuncList banmail_cb = {
     {XO_LOAD, {banmail_load}},
     {XO_HEAD, {banmail_head}},
     {XO_BODY, {banmail_body}},
+    {XO_CUR, {banmail_cur}},
 
     {Ctrl('P'), {banmail_add}},
     {'S', {banmail_sync}},

--- a/maple/bbsd.c
+++ b/maple/bbsd.c
@@ -52,9 +52,10 @@ int treat=0;
 /* ----------------------------------------------------- */
 
 void
-blog(
+blog_pid(
     const char *mode,
-    const char *msg
+    const char *msg,
+    pid_t pid
 )
 {
     char buf[512], data[256];
@@ -64,11 +65,20 @@ blog(
     if (!msg)
     {
         msg = data;
-        sprintf(data, "Stay: %d (%d)", (int)(now - ap_start) / 60, currpid);
+        sprintf(data, "Stay: %d (%d)", (int)(now - ap_start) / 60, pid);
     }
 
     sprintf(buf, "%s %-5.5s %-13s%s\n", Etime(&now), mode, cuser.userid, msg);
     f_cat(FN_USIES, buf);
+}
+
+void
+blog(
+    const char *mode,
+    const char *msg
+)
+{
+    blog_pid(mode, msg, currpid);
 }
 
 
@@ -718,7 +728,7 @@ tn_login(void)
                     if (vans("偵測到多重登入，您想刪除其他重複的 login (Y/n)嗎？[Y] ") != 'n')
                     {
                         kill(pid, SIGTERM);
-                        blog("MULTI", cuser.username);
+                        blog_pid("MULTI", cuser.username, pid);
                         break;
                     }
 

--- a/maple/board.c
+++ b/maple/board.c
@@ -1436,9 +1436,7 @@ class_zap(
         brd = bshm->bcache + chn;
         if (!(brd->battr & BRD_NOZAP) || (brd_bits[chn] & BRD_Z_BIT))
         {
-            move(3 + num - xo->top, 0);
             brd_bits[chn] ^= BRD_Z_BIT;
-            class_item(num + 1, chn);
             return XO_CUR;
         }
     }

--- a/maple/board.c
+++ b/maple/board.c
@@ -763,7 +763,7 @@ brd_usies_BMlog(void)
 
 /* 081206.cache: ¦n¤ÍªO­×¥¿ */
 bool
-XoPost(
+XoPostSimple(
     int bno)
 {
     XO *xo;
@@ -817,12 +817,8 @@ XoPost(
         bbstate |= STAT_MODERATED;
 #endif
 
-    if (/*!(bits & BRD_V_BIT) && */(cuser.ufo2 & UFO2_BNOTE))
-    {
+    if (!(bits & BRD_V_BIT))
         *str_bit = bits | BRD_V_BIT;
-        brd_fpath(fpath, currboard, FN_NOTE);
-        more(fpath, NULL);
-    }
 
     brd_fpath(fpath, currboard, fn_dir);
     xz[XZ_POST - XO_ZONE].xo = xo = xo_get(fpath);
@@ -850,6 +846,20 @@ XoPost(
         brd->n_reads++;
 #endif
     return true;
+}
+
+bool
+XoPost(
+    int bno)
+{
+    const bool res = XoPostSimple(bno);
+    if (/*!(bits & BRD_V_BIT) && */(cuser.ufo2 & UFO2_BNOTE))
+    {
+        char fpath[64];
+        brd_fpath(fpath, currboard, FN_NOTE);
+        more(fpath, NULL);
+    }
+    return res;
 }
 
 

--- a/maple/board.c
+++ b/maple/board.c
@@ -1429,7 +1429,7 @@ class_zap(
             move(3 + num - xo->top, 0);
             brd_bits[chn] ^= BRD_Z_BIT;
             class_item(num + 1, chn);
-            cursor_show(3 + num - xo->top, 0);
+            return XO_CUR;
         }
     }
 

--- a/maple/board.c
+++ b/maple/board.c
@@ -1248,6 +1248,16 @@ class_item(
     }
 }
 
+static int
+class_cur(
+    XO *xo)
+{
+    short *const chp = (short *) xo->xyz + xo->pos;
+    move(3 + xo->pos - xo->top, 0);
+    class_item(xo->pos + 1, *chp);
+    return XO_NONE;
+}
+
 
 static int
 class_body(
@@ -1654,6 +1664,7 @@ static KeyFuncList class_cb =
     {XO_HEAD, {class_head}},
     {XO_NECK, {class_neck}},
     {XO_BODY, {class_body}},
+    {XO_CUR, {class_cur}},
 
     {'r', {class_browse}},
     {'/', {class_search}},

--- a/maple/gem.c
+++ b/maple/gem.c
@@ -116,6 +116,16 @@ gem_item(
     }
 }
 
+static int
+gem_cur(
+    XO *xo)
+{
+    const HDR *const ghdr = (const HDR *) xo_pool_base + xo->pos;
+    move(3 + xo->pos - xo->top, 0);
+    gem_item(xo->pos + 1, ghdr);
+    return XO_NONE;
+}
+
 
 static int
 gem_body(
@@ -1438,6 +1448,7 @@ static KeyFuncList gem_cb =
     {XO_HEAD, {gem_head}},
     {XO_BODY, {gem_body}},
     {XO_FOOT, {gem_foot}},
+    {XO_CUR, {gem_cur}},
 
     {'r', {gem_browse}},
 

--- a/maple/gem.c
+++ b/maple/gem.c
@@ -501,9 +501,6 @@ gem_title(
         *ghdr = xhdr;
         num = xo->pos;
         rec_put(dir, ghdr, sizeof(HDR), num);
-        num++;
-        move(num - xo->top + 2, 0);
-        gem_item(num, ghdr);
 
         gem_log(xo->dir, "¼ÐÃD", ghdr);
         return XR_FOOT + XO_CUR;
@@ -528,9 +525,6 @@ gem_lock(
 
         num = xo->pos;
         rec_put(xo->dir, ghdr, sizeof(HDR), num);
-        num++;
-        move(num - xo->top + 2, 0);
-        gem_item(num, ghdr);
         return XO_CUR;
     }
 
@@ -551,9 +545,6 @@ gem_mark(
 
         num = xo->pos;
         rec_put(xo->dir, ghdr, sizeof(HDR), num);
-        num++;
-        move(num - xo->top + 2, 0);
-        gem_item(num, ghdr);
         return XO_CUR;
     }
 
@@ -1285,8 +1276,6 @@ gem_tag(
 
     if ((ghdr = gem_check(xo, NULL, GEM_READ)) && (tag = Tagger(ghdr->chrono, pos = xo->pos, TAG_TOGGLE)))
     {
-        move(3 + pos - xo->top, 0);
-        gem_item(pos + 1, ghdr);
         return XO_CUR + 1;
     }
 

--- a/maple/gem.c
+++ b/maple/gem.c
@@ -494,9 +494,9 @@ gem_title(
         num++;
         move(num - xo->top + 2, 0);
         gem_item(num, ghdr);
-        cursor_show(num - xo->top + 2, 0);
 
         gem_log(xo->dir, "¼ÐÃD", ghdr);
+        return XR_FOOT + XO_CUR;
     }
     return XO_FOOT;
 }
@@ -521,7 +521,7 @@ gem_lock(
         num++;
         move(num - xo->top + 2, 0);
         gem_item(num, ghdr);
-        cursor_show(num - xo->top + 2, 0);
+        return XO_CUR;
     }
 
     return XO_NONE;
@@ -544,7 +544,7 @@ gem_mark(
         num++;
         move(num - xo->top + 2, 0);
         gem_item(num, ghdr);
-        cursor_show(num - xo->top + 2, 0);
+        return XO_CUR;
     }
 
     return XO_NONE;
@@ -1277,7 +1277,7 @@ gem_tag(
     {
         move(3 + pos - xo->top, 0);
         gem_item(pos + 1, ghdr);
-        cursor_show(3 + pos - xo->top, 0);
+        return XO_CUR + 1;
     }
 
     /* return XO_NONE; */

--- a/maple/mail.c
+++ b/maple/mail.c
@@ -2484,9 +2484,7 @@ mbox_mark(
 
     move(3 + cur, 0);
     mbox_item(pos + 1, mhdr);
-    cursor_show(3 + cur, 0);
-
-    return XO_NONE;
+    return XO_CUR;
 }
 
 
@@ -2505,7 +2503,7 @@ mbox_tag(
     {
         move(3 + cur, 0);
         mbox_item(pos + 1, hdr);
-        cursor_show(3 + cur, 0);
+        return XO_CUR + 1;
     }
 
     /* return XO_NONE; */

--- a/maple/mail.c
+++ b/maple/mail.c
@@ -2491,9 +2491,6 @@ mbox_mark(
 
     mhdr->xmode ^= MAIL_MARKED;
     rec_put(xo->dir, mhdr, sizeof(HDR), pos);
-
-    move(3 + cur, 0);
-    mbox_item(pos + 1, mhdr);
     return XO_CUR;
 }
 
@@ -2511,8 +2508,6 @@ mbox_tag(
 
     if ((tag = Tagger(hdr->chrono, pos, TAG_TOGGLE)))
     {
-        move(3 + cur, 0);
-        mbox_item(pos + 1, hdr);
         return XO_CUR + 1;
     }
 

--- a/maple/mail.c
+++ b/maple/mail.c
@@ -1289,7 +1289,7 @@ int
 m_setmboxdir(void)
 {
 
-    char upath[128], fpath1[128], fpath2[128], id[5];
+    char upath[128], fpath1[128], id[5];
 
     pmsg2("警告：本功\能只能在信箱已毀損時使用");
     pmsg2("警告：重建索引並不能保證信箱的完整");
@@ -1304,10 +1304,8 @@ m_setmboxdir(void)
 
         sprintf(fpath1, BBSHOME "/usr/%s/%s", id, cuser.userid);
 
-        sprintf(fpath2, BBSHOME "/" BINARY_SUFFIX "redir");
-
         chdir(fpath1);
-        system(fpath2);
+        PROC_CMD(BBSHOME "/" BINARY_SUFFIX "redir", NULL);
         f_mv(".DIR.@", FN_DIR);
         chdir(BBSHOME);
 

--- a/maple/mail.c
+++ b/maple/mail.c
@@ -1289,7 +1289,7 @@ int
 m_setmboxdir(void)
 {
 
-    char upath[128], fpath1[128], fpath2[128], fpath3[128], id[5];
+    char upath[128], fpath1[128], fpath2[128], id[5];
 
     pmsg2("警告：本功\能只能在信箱已毀損時使用");
     pmsg2("警告：重建索引並不能保證信箱的完整");
@@ -1305,8 +1305,6 @@ m_setmboxdir(void)
         sprintf(fpath1, BBSHOME "/usr/%s/%s", id, cuser.userid);
 
         sprintf(fpath2, BBSHOME "/" BINARY_SUFFIX "redir");
-
-        sprintf(fpath3, "mv .DIR.@ .DIR");
 
         chdir(fpath1);
         system(fpath2);

--- a/maple/mail.c
+++ b/maple/mail.c
@@ -2178,6 +2178,16 @@ mbox_item(
     hdr_outs(hdr, d_cols + 47);
 }
 
+static int
+mbox_cur(
+    XO *xo)
+{
+    const HDR *const mhdr = (const HDR *) xo_pool_base + xo->pos;
+    move(3 + xo->pos - xo->top, 0);
+    mbox_item(xo->pos + 1, mhdr);
+    return XO_NONE;
+}
+
 
 static int
 mbox_body(
@@ -2744,6 +2754,7 @@ static KeyFuncList mbox_cb =
     {XO_HEAD, {mbox_head}},
     {XO_BODY, {mbox_body}},
     {XO_FOOT, {mbox_foot}},
+    {XO_CUR, {mbox_cur}},
 
 #ifdef  HAVE_MAIL_FIX
     {'T', {mbox_title}},

--- a/maple/mail.c
+++ b/maple/mail.c
@@ -1304,7 +1304,7 @@ m_setmboxdir(void)
 
         sprintf(fpath1, BBSHOME "/usr/%s/%s", id, cuser.userid);
 
-        sprintf(fpath2, "~/bin/redir");
+        sprintf(fpath2, BBSHOME "/bin/redir");
 
         sprintf(fpath3, "mv .DIR.@ .DIR");
 

--- a/maple/mail.c
+++ b/maple/mail.c
@@ -1021,7 +1021,7 @@ do_forward(
             gem_fpath(fpath, currboard, NULL);
         }
 
-//      sprintf(cmd, "tar -zcv -f - %s | bin/base64encode > tmp/%s.tgz", fpath, userid);
+//      sprintf(cmd, "tar -zcv -f - %s | " BINARY_SUFFIX "base64encode > tmp/%s.tgz", fpath, userid);
 //      r2.20180316: try system default util to excute base64 encoding
         #ifdef __linux__
             sprintf(cmd, "tar -zcf - %s | base64 > tmp/%s.tgz", fpath, userid);
@@ -1029,7 +1029,7 @@ do_forward(
             #ifdef __FreeBSD__
                 sprintf(cmd, "tar -zcf - %s | b64encode -r %s > tmp/%s.tgz", fpath, userid, userid);
             #else
-                sprintf(cmd, "tar -zcf - %s | bin/base64encode > tmp/%s.tgz", fpath, userid);
+                sprintf(cmd, "tar -zcf - %s | " BINARY_SUFFIX "base64encode > tmp/%s.tgz", fpath, userid);
             #endif
         #endif  /* #ifdef __linux__ */
 
@@ -1304,7 +1304,7 @@ m_setmboxdir(void)
 
         sprintf(fpath1, BBSHOME "/usr/%s/%s", id, cuser.userid);
 
-        sprintf(fpath2, BBSHOME "/bin/redir");
+        sprintf(fpath2, BBSHOME "/" BINARY_SUFFIX "redir");
 
         sprintf(fpath3, "mv .DIR.@ .DIR");
 

--- a/maple/menu.c
+++ b/maple/menu.c
@@ -415,9 +415,6 @@ menu_foot(void)
 #define MENU_CHANG      0x80000000
 
 
-#define PERM_MENU       PERM_PURGE
-
-
 #ifdef __cplusplus
   #define INTERNAL extern  /* Used inside an anonymous namespace */
   #define INTERNAL_INIT /* Empty */
@@ -538,25 +535,25 @@ INTERNAL_INIT MENU menu_settingadm[] =
 /* ----------------------------------------------------- */
 INTERNAL_INIT MENU menu_reset[] =
 {
-    {{.dlfuncarg = {DL_NAME("adminutil.so", m_resetsys), (const void *)1}}, PERM_BOARD, M_DL(M_XMODE | M_ARG),
+    {{.dlfuncarg = {{DL_NAME("adminutil.so", m_resetsys)}, (const void *)1}}, PERM_BOARD, M_DL(M_XMODE) | M_ARG,
     "Camera     動態看板"},
 
-    {{.dlfuncarg = {DL_NAME("adminutil.so", m_resetsys), (const void *)2}}, PERM_BOARD, M_DL(M_XMODE | M_ARG),
+    {{.dlfuncarg = {{DL_NAME("adminutil.so", m_resetsys)}, (const void *)2}}, PERM_BOARD, M_DL(M_XMODE) | M_ARG,
     "Group      分類群組"},
 
-    {{.dlfuncarg = {DL_NAME("adminutil.so", m_resetsys), (const void *)3}}, PERM_SYSOP, M_DL(M_XMODE | M_ARG),
+    {{.dlfuncarg = {{DL_NAME("adminutil.so", m_resetsys)}, (const void *)3}}, PERM_SYSOP, M_DL(M_XMODE) | M_ARG,
     "Mail       寄信收信轉信"},
 
-    {{.dlfuncarg = {DL_NAME("adminutil.so", m_resetsys), (const void *)4}}, PERM_ADMIN, M_DL(M_XMODE | M_ARG),
+    {{.dlfuncarg = {{DL_NAME("adminutil.so", m_resetsys)}, (const void *)4}}, PERM_ADMIN, M_DL(M_XMODE) | M_ARG,
     "Killbbs    清除不正常 BBS"},
 
-    {{.dlfuncarg = {DL_NAME("adminutil.so", m_resetsys), (const void *)5}}, PERM_BOARD, M_DL(M_XMODE | M_ARG),
+    {{.dlfuncarg = {{DL_NAME("adminutil.so", m_resetsys)}, (const void *)5}}, PERM_BOARD, M_DL(M_XMODE) | M_ARG,
     "Firewall   擋信列表"},
 
-    {{.dlfuncarg = {DL_NAME("adminutil.so", m_resetsys), (const void *)6}}, PERM_CHATROOM, M_DL(M_XMODE | M_ARG),
+    {{.dlfuncarg = {{DL_NAME("adminutil.so", m_resetsys)}, (const void *)6}}, PERM_CHATROOM, M_DL(M_XMODE) | M_ARG,
     "Xchatd     重開聊天室"},
 
-    {{.dlfuncarg = {DL_NAME("adminutil.so", m_resetsys), (const void *)7}}, PERM_SYSOP, M_DL(M_XMODE | M_ARG),
+    {{.dlfuncarg = {{DL_NAME("adminutil.so", m_resetsys)}, (const void *)7}}, PERM_SYSOP, M_DL(M_XMODE) | M_ARG,
     "All        全部"},
 
     {{.menu = menu_admin}, PERM_MENU + 'K', M_ADMIN,
@@ -735,25 +732,25 @@ INTERNAL_INIT MENU menu_talk[] =
 INTERNAL_INIT MENU menu_information[] =
 {
 
-    {{.funcarg = {menumore, "gem/@/@pop"}}, 0, M_READA | M_ARG,
+    {{.funcarg = {{menumore}, "gem/@/@pop"}}, 0, M_READA | M_ARG,
     "Login      上站次數排行榜"},
 
-    {{.funcarg = {menumore, "gem/@/@-act"}}, 0, M_READA | M_ARG,
+    {{.funcarg = {{menumore}, "gem/@/@-act"}}, 0, M_READA | M_ARG,
     "Today      今日上線人次統計"},
 
-    {{.funcarg = {menumore, "gem/@/@=act"}}, 0, M_READA | M_ARG,
+    {{.funcarg = {{menumore}, "gem/@/@=act"}}, 0, M_READA | M_ARG,
     "Yesterday  昨日上線人次統計"},
 
-    {{.funcarg = {menumore, "gem/@/@-day"}}, 0, M_READA | M_ARG,
+    {{.funcarg = {{menumore}, "gem/@/@-day"}}, 0, M_READA | M_ARG,
     "0Day       本日十大熱門話題"},
 
-    {{.funcarg = {menumore, "gem/@/@-week"}}, 0, M_READA | M_ARG,
+    {{.funcarg = {{menumore}, "gem/@/@-week"}}, 0, M_READA | M_ARG,
     "1Week      本週五十大熱門話題"},
 
-    {{.funcarg = {menumore, "gem/@/@-month"}}, 0, M_READA | M_ARG,
+    {{.funcarg = {{menumore}, "gem/@/@-month"}}, 0, M_READA | M_ARG,
     "2Month     本月百大熱門話題"},
 
-    {{.funcarg = {menumore, "gem/@/@-year"}}, 0, M_READA | M_ARG,
+    {{.funcarg = {{menumore}, "gem/@/@-year"}}, 0, M_READA | M_ARG,
     "3Year      本年度百大熱門話題"},
 
     {{.menu = menu_xyz}, PERM_MENU + 'L', M_MMENU,
@@ -766,7 +763,7 @@ INTERNAL_INIT MENU menu_xyz[] =
     {{.menu = menu_information}, 0, M_XMENU,
     "Tops       " NICKNAME "排行榜"},
 
-    {{.funcarg = {menumore, FN_ETC_VERSION}}, 0, M_READA | M_ARG,
+    {{.funcarg = {{menumore}, FN_ETC_VERSION}}, 0, M_READA | M_ARG,
     "Version    源碼發展資訊"},
 
     {{.dl = {DL_NAME("xyz.so", x_siteinfo)}}, 0, M_DL(M_READA),
@@ -778,7 +775,7 @@ INTERNAL_INIT MENU menu_xyz[] =
     {{welcome}, 0, M_READA,
     "Welcome    觀看歡迎畫面"},
 
-    {{.funcarg = {menumore, FN_ETC_COUNTER}}, 0, M_READA | M_ARG,
+    {{.funcarg = {{menumore}, FN_ETC_COUNTER}}, 0, M_READA | M_ARG,
     "History    本站歷史軌跡"},
 
     {{.menu = menu_main}, PERM_MENU + 'T', M_SMENU,
@@ -1287,6 +1284,7 @@ domenu_redo(
     {
         const unsigned int level = cuser.userlevel;
         unsigned int mlevel;
+        unsigned int umode;
         int max;
 
 #ifdef  MENU_VERBOSE
@@ -1296,7 +1294,8 @@ domenu_redo_reload:
         for (xyz->mtail = xyz->menu;; xyz->mtail++)
         {
             mlevel = xyz->mtail->level;
-            if (mlevel & PERM_MENU)
+            umode = xyz->mtail->umode;
+            if ((umode & M_TAIL_MASK) || (mlevel & PERM_MENU))
             {
 
 #ifdef  MENU_VERBOSE
@@ -1534,11 +1533,11 @@ domenu_exec(
                 int res;
 #if !NO_SO
                 /* Thor.990212: dynamic load, with negative umode */
-                if (mmode < 0)
+                if (mmode & M_DL(0))
                 {
                     mitem.func = (int (*)(void)) DL_GET(mitem.dl.func);
                     if (!mitem.func) break;
-                    mmode = -mmode;
+                    mmode &= ~M_DL(0);
   #ifndef DL_HOTSWAP
                     mptr->item = mitem;
                     mptr->umode = mmode;
@@ -1547,7 +1546,7 @@ domenu_exec(
 #endif
                 utmp_mode(mmode & M_MASK /* = mptr->umode*/);
 
-                if ((mmode & M_MASK) <= M_XMENU)
+                if ((mmode & M_MASK) >= M_MENU && (mmode & M_MASK) < M_FUN)
                 {
                     if (xyz->cmdcur_max == 1)
                         xyz->mtail->level = PERM_MENU + mptr->desc[0];
@@ -1557,9 +1556,19 @@ domenu_exec(
                 }
 
                 if (mmode & M_ARG)
-                    res = (*mitem.funcarg.func)(mitem.funcarg.arg);
+                {
+                    if (mmode & M_XO)
+                        res = mitem.funcarg.xofunc(xo, mitem.funcarg.arg);
+                    else
+                        res = mitem.funcarg.func(mitem.funcarg.arg);
+                }
                 else
-                    res = (*mitem.func)();
+                {
+                    if (mmode & M_XO)
+                        res = mitem.xofunc(xo);
+                    else
+                        res = mitem.func();
+                }
 
                 utmp_mode(xyz->mtail->umode);
 

--- a/maple/menu.c
+++ b/maple/menu.c
@@ -1212,6 +1212,8 @@ domenu(
     int cmdlen[COUNTOF(table)];  /* Command matching length (no spaces) */
     bool keep_cmd = false;
     bool keyboard_cmd = true;
+    int item_length[COUNTOF(table)]={0};
+    int max_item_length = 0;
 
     y = gety_ref(y_ref);
     x = getx_ref(x_ref);
@@ -1274,7 +1276,7 @@ domenu(
 
         if (mode & MENU_DRAW)
         {
-            int item_length[COUNTOF(table)]={0};
+            max_item_length = 0;
 
             if (mode & MENU_FILM)
             {
@@ -1309,7 +1311,8 @@ domenu(
                     if (HAVE_UFO2_CONF(UFO2_MENU_LIGHTBAR))
                         grayout(yi, yi + 1, GRAYOUT_COLORNORM);
 
-                    item_length[i]=(cuser.ufo2 & UFO2_COLOR) ? strlen(item)-strip_ansi_len(str)-2 : 0;
+                    item_length[i] = 4 + strip_ansi_len(str);
+                    max_item_length = BMAX(max_item_length, item_length[i]);
                 }
                 clrtoeol();
             }

--- a/maple/menu.c
+++ b/maple/menu.c
@@ -1215,6 +1215,7 @@ domenu(
     int item_length[COUNTOF(table)]={0};
     int max_item_length = 0;
 
+domenu_resize:
     y = gety_ref(y_ref);
     x = getx_ref(x_ref);
     height = gety_ref(height_ref);
@@ -1572,14 +1573,10 @@ menu_key:
         cmd = vkey();
         keyboard_cmd = true;
 
-        if (gety_ref(y_ref) != y || getx_ref(x_ref) != x || gety_ref(height_ref) != height || getx_ref(width_ref) != width)
+        if (cmd == I_RESIZETERM)
         {
-            y = gety_ref(y_ref);
-            x = getx_ref(x_ref);
-            height = gety_ref(height_ref);
-            width = getx_ref(width_ref);
-
             mode = MENU_LOAD | MENU_DRAW | MENU_FILM;
+            goto domenu_resize;
         }
     }
 }

--- a/maple/menu.c
+++ b/maple/menu.c
@@ -456,19 +456,19 @@ INTERNAL_INIT MENU menu_boardadm[] =
     {{BanMail}, PERM_BOARD|PERM_SYSOP, M_BANMAIL,
     "FireWall   擋信列表"},
 
-    {{.dlfunc = DL_NAME("adminutil.so", bm_check)}, PERM_BOARD|PERM_SYSOP, M_DL(M_XMODE),
+    {{.dl = {DL_NAME("adminutil.so", bm_check)}}, PERM_BOARD|PERM_SYSOP, M_DL(M_XMODE),
     "Manage     板主確認"},
 
-    {{.dlfunc = DL_NAME("adminutil.so", m_expire)}, PERM_BOARD|PERM_SYSOP, M_DL(M_XMODE),
+    {{.dl = {DL_NAME("adminutil.so", m_expire)}}, PERM_BOARD|PERM_SYSOP, M_DL(M_XMODE),
     "DExpire    清除看板刪除文章"},
 
-    {{.dlfunc = DL_NAME("adminutil.so", mail_to_bm)}, PERM_SYSOP, M_DL(M_XMODE),
+    {{.dl = {DL_NAME("adminutil.so", mail_to_bm)}}, PERM_SYSOP, M_DL(M_XMODE),
     "ToBM       寄信給板主"},
 
-    {{.dlfunc = DL_NAME("adminutil.so", mail_to_all)}, PERM_SYSOP, M_DL(M_XMODE),
+    {{.dl = {DL_NAME("adminutil.so", mail_to_all)}}, PERM_SYSOP, M_DL(M_XMODE),
     "Alluser    系統通告"},
 
-    {{.dlfunc = DL_NAME("personal.so", personal_admin)}, PERM_BOARD|PERM_SYSOP, M_DL(M_XMODE),
+    {{.dl = {DL_NAME("personal.so", personal_admin)}}, PERM_BOARD|PERM_SYSOP, M_DL(M_XMODE),
     "Personal   個人板審核"},
 
     {{.menu = menu_admin}, PERM_MENU + 'N', M_ADMIN,
@@ -480,24 +480,24 @@ INTERNAL_INIT MENU menu_accadm[] =
     {{m_user}, PERM_ACCOUNTS, M_SYSTEM,
     "User       使用者資料"},
 
-    {{.dlfunc = DL_NAME("bank.so", money_back)}, PERM_ACCOUNTS, M_DL(M_XMODE),
+    {{.dl = {DL_NAME("bank.so", money_back)}}, PERM_ACCOUNTS, M_DL(M_XMODE),
     "GetMoney   匯入舊夢幣"},
 
 #ifdef  HAVE_SONG
-    {{.dlfunc = DL_NAME("song.so", AddRequestTimes)}, PERM_KTV, M_DL(M_XMODE),
+    {{.dl = {DL_NAME("song.so", AddRequestTimes)}}, PERM_KTV, M_DL(M_XMODE),
     "Addsongs   增加點歌次數"},
 #endif
 
-    {{.dlfunc = DL_NAME("passwd.so", new_passwd)}, PERM_SYSOP, M_DL(M_XMODE),
+    {{.dl = {DL_NAME("passwd.so", new_passwd)}}, PERM_SYSOP, M_DL(M_XMODE),
     "Password   重送新密碼"},
 
 #ifdef  HAVE_REGISTER_FORM
-    {{.dlfunc = m_register}, PERM_ACCOUNTS, M_SYSTEM,
+    {{.dl = {m_register}}, PERM_ACCOUNTS, M_SYSTEM,
     "1Register  審核註冊表單"},
 #endif
 
 #ifdef HAVE_OBSERVE_LIST
-    {{.dlfunc = DL_NAME("observe.so", Observe_list)}, PERM_SYSOP|PERM_BOARD, M_DL(M_XMODE),
+    {{.dl = {DL_NAME("observe.so", Observe_list)}}, PERM_SYSOP|PERM_BOARD, M_DL(M_XMODE),
     "2Observe   系統觀察名單"},
 #endif
 
@@ -508,25 +508,25 @@ INTERNAL_INIT MENU menu_accadm[] =
 INTERNAL_INIT MENU menu_settingadm[] =
 {
 
-    {{.dlfunc = DL_NAME("adminutil.so", m_xfile)}, PERM_SYSOP, M_DL(M_XFILES),
+    {{.dl = {DL_NAME("adminutil.so", m_xfile)}}, PERM_SYSOP, M_DL(M_XFILES),
     "File       編輯系統檔案"},
 
-    {{.dlfunc = DL_NAME("adminutil.so", m_xhlp)}, PERM_SYSOP, M_DL(M_XFILES),
+    {{.dl = {DL_NAME("adminutil.so", m_xhlp)}}, PERM_SYSOP, M_DL(M_XFILES),
     "Hlp        編輯說明檔案"},
 
-    {{.dlfunc = DL_NAME("admin.so", Admin)}, PERM_SYSOP, M_DL(M_XMODE),
+    {{.dl = {DL_NAME("admin.so", Admin)}}, PERM_SYSOP, M_DL(M_XMODE),
     "Operator   系統管理員列表"},
 
-    {{.dlfunc = DL_NAME("chatmenu.so", Chatmenu)}, PERM_CHATROOM|PERM_SYSOP, M_DL(M_XMODE),
+    {{.dl = {DL_NAME("chatmenu.so", Chatmenu)}}, PERM_CHATROOM|PERM_SYSOP, M_DL(M_XMODE),
     "Chatmenu   " CHATROOMNAME "動詞"},
 
-    {{.dlfunc = DL_NAME("violate.so", Violate)}, PERM_SYSOP, M_DL(M_XMODE),
+    {{.dl = {DL_NAME("violate.so", Violate)}}, PERM_SYSOP, M_DL(M_XMODE),
     "Violate    處罰名單"},
 
-    {{.dlfunc = DL_NAME("adminutil.so", special_search)}, PERM_SYSOP, M_DL(M_XMODE),
+    {{.dl = {DL_NAME("adminutil.so", special_search)}}, PERM_SYSOP, M_DL(M_XMODE),
     "XSpecial   特殊搜尋"},
 
-    {{.dlfunc = DL_NAME("adminutil.so", update_all)}, PERM_SYSOP, M_DL(M_XMODE),
+    {{.dl = {DL_NAME("adminutil.so", update_all)}}, PERM_SYSOP, M_DL(M_XMODE),
     "Database   系統資料庫更新"},
 
     {{.menu = menu_admin}, PERM_MENU + 'X', M_ADMIN,
@@ -581,7 +581,7 @@ INTERNAL_INIT MENU menu_admin[] =
     {{.menu = menu_settingadm}, PERM_ADMIN, M_ADMIN,
     "Data       系統資料庫設定"},
 
-    {{.dlfunc = DL_NAME("innbbs.so", a_innbbs)}, PERM_BOARD, M_DL(M_SYSTEM),
+    {{.dl = {DL_NAME("innbbs.so", a_innbbs)}}, PERM_BOARD, M_DL(M_SYSTEM),
     "InnBBS     轉信設定"},
 
     {{.menu = menu_reset}, PERM_ADMIN, M_ADMIN,
@@ -642,7 +642,7 @@ INTERNAL_INIT MENU menu_mail[] =
     "Group      群組寄信"},
 #endif
 
-    {{.dlfunc = DL_NAME("contact.so", Contact)}, PERM_INTERNET, M_DL(M_XMODE),
+    {{.dl = {DL_NAME("contact.so", Contact)}}, PERM_INTERNET, M_DL(M_XMODE),
     "Contact    聯絡名單"},
 
     {{m_setforward}, PERM_INTERNET, M_SMAIL,
@@ -700,7 +700,7 @@ INTERNAL_INIT MENU menu_talk[] =
     {{t_banmsg}, PERM_BASIC, M_XMODE,
     "Banmsg     拒收訊息名單"},
 #endif
-    {{.dlfunc = DL_NAME("aloha.so", t_aloha)}, PERM_BASIC, M_DL(M_XMODE),
+    {{.dl = {DL_NAME("aloha.so", t_aloha)}}, PERM_BASIC, M_DL(M_XMODE),
     "Aloha      上站通知名單"},
 
     {{t_pager}, PERM_BASIC, M_XMODE,
@@ -713,7 +713,7 @@ INTERNAL_INIT MENU menu_talk[] =
     "Query      查詢網友"},
 
     /* Thor.990220: chatroom client 改採外掛 */
-    {{.dlfunc = DL_NAME("chat.so", t_chat)}, PERM_CHAT, M_DL(M_CHAT),
+    {{.dl = {DL_NAME("chat.so", t_chat)}}, PERM_CHAT, M_DL(M_CHAT),
     "ChatRoom   " NICKNAME CHATROOMNAME},
 
     {{t_recall}, PERM_BASIC, M_XMODE,
@@ -769,7 +769,7 @@ INTERNAL_INIT MENU menu_xyz[] =
     {{.funcarg = {menumore, FN_ETC_VERSION}}, 0, M_READA | M_ARG,
     "Version    源碼發展資訊"},
 
-    {{.dlfunc = DL_NAME("xyz.so", x_siteinfo)}, 0, M_DL(M_READA),
+    {{.dl = {DL_NAME("xyz.so", x_siteinfo)}}, 0, M_DL(M_READA),
     "Xinfo      系統程式資訊"},
 
     {{pad_view}, 0, M_READA,
@@ -815,7 +815,7 @@ INTERNAL_INIT MENU menu_reg[] =
     {{u_xfile}, PERM_BASIC, M_UFILES,
     "Xfile      編輯個人檔案"},
 
-    {{.dlfunc = DL_NAME("list.so", List)}, PERM_VALID, M_DL(M_XMODE),
+    {{.dl = {DL_NAME("list.so", List)}}, PERM_VALID, M_DL(M_XMODE),
     "1List      群組名單"},
 
     {{.menu = menu_user}, PERM_MENU + 'I', M_MMENU,
@@ -831,14 +831,14 @@ INTERNAL_INIT MENU menu_user[] =
     {{u_lock}, PERM_BASIC, M_XMODE,
     "Lock       鎖定螢幕"},
 
-    {{.dlfunc = DL_NAME("memorandum.so", Memorandum)}, PERM_VALID, M_DL(M_XMODE),
+    {{.dl = {DL_NAME("memorandum.so", Memorandum)}}, PERM_VALID, M_DL(M_XMODE),
     "Note       備忘錄"},
 
-    {{.dlfunc = DL_NAME("pnote.so", main_note)}, PERM_VALID, M_DL(M_XMODE),
+    {{.dl = {DL_NAME("pnote.so", main_note)}}, PERM_VALID, M_DL(M_XMODE),
     "PNote      個人答錄機"},
 
 #ifdef  HAVE_CLASSTABLEALERT
-    {{.dlfunc = DL_NAME("classtable2.so", main_classtable)}, PERM_VALID, M_DL(M_XMODE),
+    {{.dl = {DL_NAME("classtable2.so", main_classtable)}}, PERM_VALID, M_DL(M_XMODE),
     "2Table     新版個人功\課表"},
 #endif
 
@@ -862,19 +862,19 @@ INTERNAL MENU menu_service[];
 
 INTERNAL_INIT MENU menu_game[] =
 {
-    {{.dlfunc = DL_NAME("bj.so", BlackJack)}, PERM_VALID, M_DL(M_XMODE),
+    {{.dl = {DL_NAME("bj.so", BlackJack)}}, PERM_VALID, M_DL(M_XMODE),
     "BlackJack  " NICKNAME "黑傑克"},
 
-    {{.dlfunc = DL_NAME("guessnum.so", fightNum)}, PERM_VALID, M_DL(M_XMODE),
+    {{.dl = {DL_NAME("guessnum.so", fightNum)}}, PERM_VALID, M_DL(M_XMODE),
     "FightNum   數字大決戰"},
 
-    {{.dlfunc = DL_NAME("guessnum.so", guessNum)}, PERM_VALID, M_DL(M_XMODE),
+    {{.dl = {DL_NAME("guessnum.so", guessNum)}}, PERM_VALID, M_DL(M_XMODE),
     "GuessNum   傻瓜猜數字"},
 
-    {{.dlfunc = DL_NAME("mine.so", Mine)}, PERM_VALID, M_DL(M_XMODE),
+    {{.dl = {DL_NAME("mine.so", Mine)}}, PERM_VALID, M_DL(M_XMODE),
     "Mine       " NICKNAME "踩地雷"},
 
-    {{.dlfunc = DL_NAME("pip.so", p_pipple)}, PERM_VALID, M_DL(M_XMODE),
+    {{.dl = {DL_NAME("pip.so", p_pipple)}}, PERM_VALID, M_DL(M_XMODE),
     "Pip        " NICKNAME "戰鬥雞"},
 
     {{.menu = menu_service}, PERM_MENU + 'F', M_UMENU,
@@ -889,13 +889,13 @@ INTERNAL_INIT MENU menu_game[] =
 INTERNAL_INIT MENU menu_special[] =
 {
 
-    {{.dlfunc = DL_NAME("personal.so", personal_apply)}, PERM_VALID, M_DL(M_XMODE),
+    {{.dl = {DL_NAME("personal.so", personal_apply)}}, PERM_VALID, M_DL(M_XMODE),
     "PBApply      申請個人看板"},
 
-    {{.dlfunc = DL_NAME("bank.so", bank_main)}, PERM_VALID, M_DL(M_XMODE),
+    {{.dl = {DL_NAME("bank.so", bank_main)}}, PERM_VALID, M_DL(M_XMODE),
     "Bank       　銀行"},
 
-    {{.dlfunc = DL_NAME("shop.so", shop_main)}, PERM_VALID, M_DL(M_XMODE),
+    {{.dl = {DL_NAME("shop.so", shop_main)}}, PERM_VALID, M_DL(M_XMODE),
     "Pay        　商店"},
 
 #ifdef HAVE_SONG
@@ -919,13 +919,13 @@ INTERNAL_INIT MENU menu_special[] =
 #ifdef HAVE_SONG
 INTERNAL_INIT MENU menu_song[] =
 {
-    {{.dlfunc = DL_NAME("song.so", XoSongMain)}, PERM_VALID, M_DL(M_XMODE),
+    {{.dl = {DL_NAME("song.so", XoSongMain)}}, PERM_VALID, M_DL(M_XMODE),
     "Request       點歌歌本"},
 
-    {{.dlfunc = DL_NAME("song.so", XoSongLog)}, PERM_VALID, M_DL(M_XMODE),
+    {{.dl = {DL_NAME("song.so", XoSongLog)}}, PERM_VALID, M_DL(M_XMODE),
     "OrderSongs    點歌紀錄"},
 
-    {{.dlfunc = DL_NAME("song.so", XoSongSub)}, PERM_VALID, M_DL(M_XMODE),
+    {{.dl = {DL_NAME("song.so", XoSongSub)}}, PERM_VALID, M_DL(M_XMODE),
     "Submit        投稿專區"},
 
     {{.menu = menu_special}, PERM_MENU + 'R', M_XMENU,
@@ -963,10 +963,10 @@ INTERNAL_INIT MENU menu_service[] =
 
 /* 091007.cache: 拉人灌票沒意義... */
 
-    {{.dlfunc = DL_NAME("newboard.so", XoNewBoard)}, PERM_VALID, M_DL(M_XMODE),
+    {{.dl = {DL_NAME("newboard.so", XoNewBoard)}}, PERM_VALID, M_DL(M_XMODE),
     "Cosign    【 連署申請區 】"},
 
-    {{.dlfunc = DL_NAME("vote.so", SystemVote)}, PERM_POST, M_DL(M_XMODE),
+    {{.dl = {DL_NAME("vote.so", SystemVote)}}, PERM_POST, M_DL(M_XMODE),
     "Vote      【 系統投票區 】"},
 
     {{system_result}, 0, M_READA,
@@ -1536,7 +1536,7 @@ domenu_exec(
                 /* Thor.990212: dynamic load, with negative umode */
                 if (mmode < 0)
                 {
-                    mitem.func = (int (*)(void)) DL_GET(mitem.dlfunc);
+                    mitem.func = (int (*)(void)) DL_GET(mitem.dl.func);
                     if (!mitem.func) break;
                     mmode = -mmode;
   #ifndef DL_HOTSWAP

--- a/maple/menu.c
+++ b/maple/menu.c
@@ -1440,7 +1440,7 @@ domenu_resize:
 
 #ifdef EVERY_Z
         case Ctrl('Z'):
-            every_Z();          /* Thor: ctrl-Z everywhere */
+            every_Z(NULL);      /* Thor: ctrl-Z everywhere */
             goto menu_key;
 #endif
         case Ctrl('U'):

--- a/maple/myfavorite.c
+++ b/maple/myfavorite.c
@@ -66,6 +66,16 @@ myfavorite_item(
 }
 
 static int
+myfavorite_cur(
+    XO *xo)
+{
+    const HDR *const myfavorite = (const HDR *) xo_pool_base + xo->pos;
+    move(3 + xo->pos - xo->top, 0);
+    myfavorite_item(xo->pos + 1, myfavorite);
+    return XO_NONE;
+}
+
+static int
 myfavorite_body(
     XO *xo)
 {
@@ -493,6 +503,7 @@ KeyFuncList myfavorite_cb =
     {XO_LOAD, {myfavorite_load}},
     {XO_HEAD, {myfavorite_head}},
     {XO_BODY, {myfavorite_body}},
+    {XO_CUR, {myfavorite_cur}},
 
     {Ctrl('P'), {myfavorite_add}},
     {'a', {myfavorite_add}},

--- a/maple/popupmenu.c
+++ b/maple/popupmenu.c
@@ -374,6 +374,7 @@ do_menu(
 
     scr_dump(&old_screen);
 
+do_menu_redraw:
     y = gety_ref(y_ref);
     x = getx_ref(x_ref);
 
@@ -382,16 +383,12 @@ do_menu(
     while (1)  /* verit . user ¿ï¾Ü */
     {
         c = vkey();
-        if (gety_ref(y_ref) != y || getx_ref(x_ref) != x)
+        if (c == I_RESIZETERM)
         {
             /* Screen size changed and redraw is needed */
             /* clear */
             scr_restore_keep(&old_screen);
-            /* update position */
-            y = gety_ref(y_ref);
-            x = getx_ref(x_ref);
-            /* redraw */
-            draw_menu((const MENU *const *)table, num+1, title, y, x, cur);
+            goto do_menu_redraw;
         }
 
         old_cur = cur;
@@ -514,7 +511,7 @@ popupmenu_ans(const char *const desc[], const char *title, int y_ref, int x_ref)
 {
     int y, x;
     int cur, old_cur, num, tmp;
-    int c;
+    int c = KEY_NONE;
     char t[64];
     char hotkey;
     screen_backup_t old_screen;
@@ -522,33 +519,36 @@ popupmenu_ans(const char *const desc[], const char *title, int y_ref, int x_ref)
     scr_dump(&old_screen);
     hotkey = desc[0][0];
 
+popupmenu_ans_redraw:
     y = gety_ref(y_ref);
     x = getx_ref(x_ref);
 
-    sprintf(t, "¡i%s¡j", title);
+    if (c != I_RESIZETERM)
+        sprintf(t, "¡i%s¡j", title);
+
     num = draw_menu_des(desc, t, y, x, 0);
-    cur = old_cur = 0;
-    for (tmp=0; tmp<num; tmp++)
+
+    if (c != I_RESIZETERM)
     {
-        if (desc[tmp+1][0] == hotkey)
-            cur = old_cur = tmp;
+        cur = old_cur = 0;
+        for (tmp=0; tmp<num; tmp++)
+        {
+            if (desc[tmp+1][0] == hotkey)
+                cur = old_cur = tmp;
+        }
     }
+
     draw_ans_item(desc[cur+1], 1, y+cur, x, hotkey);
 
     while (1)
     {
         c = vkey();
-        if (gety_ref(y_ref) != y || getx_ref(x_ref) != x)
+        if (c == I_RESIZETERM)
         {
             /* Screen size changed and redraw is needed */
             /* clear */
             scr_restore_keep(&old_screen);
-            /* update position */
-            y = gety_ref(y_ref);
-            x = getx_ref(x_ref);
-            /* redraw */
-            num = draw_menu_des(desc, t, y, x, 0);
-            draw_ans_item(desc[cur+1], 1, y+cur, x, hotkey);
+            goto popupmenu_ans_redraw;
         }
 
         old_cur = cur;

--- a/maple/popupmenu.c
+++ b/maple/popupmenu.c
@@ -387,7 +387,16 @@ do_menu_redraw:
         {
             /* Screen size changed and redraw is needed */
             /* clear */
-            scr_restore_keep(&old_screen);
+            if (xo)
+            {
+                /* Redraw and redump */
+                scr_restore_free(&old_screen);
+                xover_exec_cb(xo, XO_HEAD);
+                cursor_show(3 + xo->pos - xo->top, 0);
+                scr_dump(&old_screen);
+            }
+            else
+                scr_restore_keep(&old_screen);
             goto do_menu_redraw;
         }
 

--- a/maple/popupmenu.c
+++ b/maple/popupmenu.c
@@ -63,8 +63,8 @@ do_cmd(MENU *mptr, XO *xo, int y, int x)
 #if !NO_SO
     if (mmode < 0)
     {
-        mitem.xofunc = (int (*)(XO *xo)) DL_GET(mitem.dlfunc);
-        if (!mitem.xofunc)
+        mitem.func = (int (*)(void)) DL_GET(mitem.dl.func);
+        if (!mitem.func)
             return 0;
         mmode = -mmode;
   #ifndef DL_HOTSWAP
@@ -80,7 +80,7 @@ do_cmd(MENU *mptr, XO *xo, int y, int x)
     {
 #if !NO_SO
         case POPUP_SO :
-            mitem.func = (int (*)(void)) DL_GET(mitem.dlfunc);
+            mitem.func = (int (*)(void)) DL_GET(mitem.dl.func);
             if (!mitem.func)
             {
                 scr_free(&old_screen);

--- a/maple/popupmenu.c
+++ b/maple/popupmenu.c
@@ -676,8 +676,13 @@ int pmsg(const char *msg)
 
     scr_dump(&old_screen);
 
-    pmsg_body(msg);
-    cc = vkey();
+    for (;;)
+    {
+        pmsg_body(msg);
+        if ((cc = vkey()) != I_RESIZETERM)
+            break;
+        scr_restore_keep(&old_screen);
+    }
 
     scr_restore_free(&old_screen);
     return cc;

--- a/maple/post.c
+++ b/maple/post.c
@@ -1729,7 +1729,7 @@ post_tag(
     {
         move(3 + cur, 0);
         post_item(pos + 1, hdr);
-        cursor_show(3 + cur, 0);
+        return XO_CUR + 1;
     }
 
     /* return XO_NONE; */
@@ -1762,7 +1762,7 @@ post_mark(
         rec_put(xo->dir, hdr, sizeof(HDR), xo->key == XZ_POST ? pos : hdr->xid);
         move(3 + cur, 0);
         post_item(pos + 1, hdr);
-        cursor_show(3 + cur, 0);
+        return XO_CUR;
 
     }
     return XO_NONE;
@@ -1862,8 +1862,7 @@ post_delete(
             lazy_delete(fhdr); /* Thor.980911: 註解: 修改 xo_pool */
             move(3 + cur, 0);
             post_item(++pos, fhdr);
-            cursor_show(3 + cur, 0);
-            return XO_FOOT;
+            return XR_FOOT + XO_CUR;
         }
 
         if (by_BM/* && (bbstate & BRD_NOTRAN) && !(fhdr->xmode & POST_BOTTOM)*/)
@@ -1932,7 +1931,7 @@ post_delete(
             lazy_delete(fhdr); /* Thor.980911: 註解: 修改 xo_pool */
             move(3 + cur, 0);
             post_item(++pos, fhdr);
-            cursor_show(3 + cur, 0);
+            return XR_FOOT + XO_CUR;
         }
     }
     return XO_FOOT;
@@ -2029,7 +2028,7 @@ post_complete(
         rec_put(xo->dir, hdr, sizeof(HDR), xo->key == XZ_POST ? pos : hdr->xid);
         move(3 + cur, 0);
         post_item(pos + 1, hdr);
-        cursor_show(3 + cur, 0);
+        return XO_CUR;
     }
     return XO_NONE;
 }
@@ -2061,7 +2060,7 @@ post_lock(
         rec_put(xo->dir, hdr, sizeof(HDR), xo->key == XZ_POST ? pos : hdr->xid);
         move(3 + cur, 0);
         post_item(pos + 1, hdr);
-        cursor_show(3 + cur, 0);
+        return XO_CUR;
     }
     return XO_NONE;
 }
@@ -2273,7 +2272,7 @@ post_undelete(
     {
         move(3 + cur, 0);
         post_item(++pos, fhdr);
-        cursor_show(3 + cur, 0);
+        return XO_CUR + 1;
     }
     /*return XO_LOAD;*/
     return XO_MOVE + XO_REL + 1;
@@ -2315,7 +2314,7 @@ post_expire(
     {
         move(3 + cur, 0);
         post_item(++pos, fhdr);
-        cursor_show(3 + cur, 0);
+        return XO_CUR;
     }
     return XO_NONE;
 
@@ -2350,7 +2349,7 @@ post_unexpire(
     {
         move(3 + cur, 0);
         post_item(++pos, fhdr);
-        cursor_show(3 + cur, 0);
+        return XO_CUR;
     }
     return XO_NONE;
 }
@@ -2814,11 +2813,11 @@ post_title(
         rec_put(xo->dir, fhdr, sizeof(HDR), pos);
         move(3 + cur, 0);
         post_item(++pos, fhdr);
-        cursor_show(3 + cur, 0);
 
         /* 0911105.cache: 順便改內文標題 */
         header_replace(xo, fhdr);
 
+        return XR_FOOT + XO_CUR;
     }
     return XO_FOOT;
 }
@@ -3149,9 +3148,7 @@ post_resetscore(
 
             move(3 + cur, 0);
             post_item(pos + 1, hdr);
-            cursor_show(3 + cur, 0);
-
-            return XO_LOAD;
+            return XR_LOAD + XO_CUR;
         //}
 
 

--- a/maple/post.c
+++ b/maple/post.c
@@ -1737,8 +1737,6 @@ post_tag(
 
     if ((tag = Tagger(hdr->chrono, pos, TAG_TOGGLE)))
     {
-        move(3 + cur, 0);
-        post_item(pos + 1, hdr);
         return XO_CUR + 1;
     }
 
@@ -1770,8 +1768,6 @@ post_mark(
 
         hdr->xmode ^= POST_MARKED;
         rec_put(xo->dir, hdr, sizeof(HDR), xo->key == XZ_POST ? pos : hdr->xid);
-        move(3 + cur, 0);
-        post_item(pos + 1, hdr);
         return XO_CUR;
 
     }
@@ -1870,8 +1866,6 @@ post_delete(
         if (by_BM && (fhdr->xmode & POST_BOTTOM))
         {
             lazy_delete(fhdr); /* Thor.980911: 註解: 修改 xo_pool */
-            move(3 + cur, 0);
-            post_item(++pos, fhdr);
             return XR_FOOT + XO_CUR;
         }
 
@@ -1939,8 +1933,6 @@ post_delete(
 #endif
             }
             lazy_delete(fhdr); /* Thor.980911: 註解: 修改 xo_pool */
-            move(3 + cur, 0);
-            post_item(++pos, fhdr);
             return XR_FOOT + XO_CUR;
         }
     }
@@ -2036,8 +2028,6 @@ post_complete(
 
         hdr->xmode ^= POST_COMPLETE;
         rec_put(xo->dir, hdr, sizeof(HDR), xo->key == XZ_POST ? pos : hdr->xid);
-        move(3 + cur, 0);
-        post_item(pos + 1, hdr);
         return XO_CUR;
     }
     return XO_NONE;
@@ -2068,8 +2058,6 @@ post_lock(
 
         hdr->xmode ^= POST_LOCK;
         rec_put(xo->dir, hdr, sizeof(HDR), xo->key == XZ_POST ? pos : hdr->xid);
-        move(3 + cur, 0);
-        post_item(pos + 1, hdr);
         return XO_CUR;
     }
     return XO_NONE;
@@ -2280,8 +2268,6 @@ post_undelete(
     fhdr->xmode &= (~(POST_MDELETE | POST_DELETE | POST_CANCEL));
     if (!rec_put(xo->dir, fhdr, sizeof(HDR), pos))
     {
-        move(3 + cur, 0);
-        post_item(++pos, fhdr);
         return XO_CUR + 1;
     }
     /*return XO_LOAD;*/
@@ -2322,8 +2308,6 @@ post_expire(
     fhdr->expire = time(0) + 86400 * 7;
     if (!rec_put(xo->dir, fhdr, sizeof(HDR), pos))
     {
-        move(3 + cur, 0);
-        post_item(++pos, fhdr);
         return XO_CUR;
     }
     return XO_NONE;
@@ -2357,8 +2341,6 @@ post_unexpire(
     fhdr->expire = 0;
     if (!rec_put(xo->dir, fhdr, sizeof(HDR), pos))
     {
-        move(3 + cur, 0);
-        post_item(++pos, fhdr);
         return XO_CUR;
     }
     return XO_NONE;
@@ -2821,8 +2803,6 @@ post_title(
     {
         *fhdr = mhdr;
         rec_put(xo->dir, fhdr, sizeof(HDR), pos);
-        move(3 + cur, 0);
-        post_item(++pos, fhdr);
 
         /* 0911105.cache: 順便改內文標題 */
         header_replace(xo, fhdr);
@@ -3155,9 +3135,6 @@ post_resetscore(
 
             strcpy(hdr->lastrecommend, cuser.userid);
             rec_put(xo->dir, hdr, sizeof(HDR), pos);
-
-            move(3 + cur, 0);
-            post_item(pos + 1, hdr);
             return XR_LOAD + XO_CUR;
         //}
 

--- a/maple/post.c
+++ b/maple/post.c
@@ -916,6 +916,16 @@ post_item(
 #endif  /* #ifdef HAVE_RECOMMEND */
 }
 
+static int
+post_cur(
+    XO *xo)
+{
+    const HDR *const fhdr = (const HDR *) xo_pool_base + xo->pos;
+    move(3 + xo->pos - xo->top, 0);
+    post_item(xo->pos + 1, fhdr);
+    return XO_NONE;
+}
+
     static int
 post_body(
     XO *xo)
@@ -4083,6 +4093,7 @@ KeyFuncList post_cb =
     {XO_HEAD, {post_head}},
     {XO_BODY, {post_body}},
     {XO_FOOT, {post_foot}},
+    {XO_CUR, {post_cur}},
 
     {'B', {post_manage}},
     {'r', {post_browse}},

--- a/maple/talk.c
+++ b/maple/talk.c
@@ -2611,7 +2611,7 @@ talk_speak(
             holdon_fd = vio_fd;
             vio_fd = 0;
             scr_dump(&old_screen);
-            every_Z();
+            every_Z(NULL);
             scr_restore_free(&old_screen);
             /* Thor.0727: ¡Ÿ≠Ï vio_fd */
             vio_fd = holdon_fd;

--- a/maple/talk.c
+++ b/maple/talk.c
@@ -666,6 +666,16 @@ pal_item(
         pal->userid, pal->ship);
 }
 
+static int
+pal_cur(
+    XO *xo)
+{
+    const PAL *const pal = (const PAL *) xo_pool_base + xo->pos;
+    move(3 + xo->pos - xo->top, 0);
+    pal_item(xo->pos + 1, pal);
+    return XO_NONE;
+}
+
 
 static int
 pal_body(
@@ -960,6 +970,7 @@ KeyFuncList pal_cb =
     {XO_LOAD, {pal_load}},
     {XO_HEAD, {pal_head}},
     {XO_BODY, {pal_body}},
+    {XO_CUR, {pal_cur}},
 
     {'a', {pal_add}},
     {'c', {pal_change}},
@@ -1054,6 +1065,16 @@ bmw_item(
                     bmw->userid, d_cols + 57, d_cols + 57, bmw->msg);
         }
     }
+}
+
+static int
+bmw_cur(
+    XO *xo)
+{
+    const BMW *const bmw = (const BMW *) xo_pool_base + xo->pos;
+    move(3 + xo->pos - xo->top, 0);
+    bmw_item(xo->pos + 1, bmw);
+    return XO_NONE;
 }
 
 
@@ -1241,6 +1262,7 @@ KeyFuncList bmw_cb =
     {XO_LOAD, {bmw_load}},
     {XO_HEAD, {bmw_head}},
     {XO_BODY, {bmw_body}},
+    {XO_CUR, {bmw_cur}},
 
     {'d', {bmw_delete}},
     {'m', {bmw_mail}},
@@ -4591,6 +4613,16 @@ banmsg_item(
     prints("%6d    %-14s%s\n", num, banmsg->userid, banmsg->ship);
 }
 
+static int
+banmsg_cur(
+    XO *xo)
+{
+    const BANMSG *const banmsg = (const BANMSG *) xo_pool_base + xo->pos;
+    move(3 + xo->pos - xo->top, 0);
+    banmsg_item(xo->pos + 1, banmsg);
+    return XO_NONE;
+}
+
 
 static int
 banmsg_body(
@@ -4809,6 +4841,7 @@ KeyFuncList banmsg_cb =
     {XO_LOAD, {banmsg_load}},
     {XO_HEAD, {banmsg_head}},
     {XO_BODY, {banmsg_body}},
+    {XO_CUR, {banmsg_cur}},
 
     {'a', {banmsg_add}},
     {'c', {banmsg_change}},

--- a/maple/talk.c
+++ b/maple/talk.c
@@ -902,8 +902,6 @@ pal_change(
     if (memcmp(pal, &mate, sizeof(PAL)))
     {
         rec_put(xo->dir, pal, sizeof(PAL), pos);
-        move(3 + cur, 0);
-        pal_item(++pos, pal);
         return XR_FOOT + XO_CUR;
     }
 
@@ -4775,8 +4773,6 @@ banmsg_change(
     if (memcmp(banmsg, &mate, sizeof(BANMSG)))
     {
         rec_put(xo->dir, banmsg, sizeof(BANMSG), pos);
-        move(3 + cur, 0);
-        banmsg_item(++pos, banmsg);
         return XR_FOOT + XO_CUR;
     }
 

--- a/maple/talk.c
+++ b/maple/talk.c
@@ -894,7 +894,7 @@ pal_change(
         rec_put(xo->dir, pal, sizeof(PAL), pos);
         move(3 + cur, 0);
         pal_item(++pos, pal);
-        cursor_show(3 + cur, 0);
+        return XR_FOOT + XO_CUR;
     }
 
     return XO_FOOT;
@@ -4745,7 +4745,7 @@ banmsg_change(
         rec_put(xo->dir, banmsg, sizeof(BANMSG), pos);
         move(3 + cur, 0);
         banmsg_item(++pos, banmsg);
-        cursor_show(3 + cur, 0);
+        return XR_FOOT + XO_CUR;
     }
 
     return XO_FOOT;

--- a/maple/visio.c
+++ b/maple/visio.c
@@ -1789,11 +1789,9 @@ igetch(void)
                             continue;
 
                         if (cutmp)
-                        {
-
-                            idle = 0;
                             time(&cutmp->idle_time);
-                        }
+                        else
+                            idle = 0;
 #ifdef  HAVE_SHOWNUMMSG
                         if (cutmp)
                             cutmp->num_msg = 0;
@@ -1809,7 +1807,10 @@ igetch(void)
                     if (cc < 60)                /* paging timeout */
                         return I_TIMEOUT;
 
-                    idle = (time(NULL) - cutmp->idle_time);
+                    if (cutmp)
+                        idle = (time(NULL) - cutmp->idle_time);
+                    else
+                        idle += cc;
                     vio_to.tv_sec = cc + 60;  /* Thor.980806: 每次 timeout都增加60秒,
                                                               所以片子愈換愈慢, 好懶:p */
                     /* Thor.990201: 註解: 除了talk_rqst, chat之外, 需要在動一動之後

--- a/maple/visio.c
+++ b/maple/visio.c
@@ -1399,8 +1399,18 @@ int
 vmsg(
     const char *msg)             /* length <= 54 */
 {
-    vmsg_body(msg);
-    return vkey();
+    int b_lines_prev = b_lines;
+    int res_key;
+    for (;;)
+    {
+        vmsg_body(msg);
+        if ((res_key = vkey()) != I_RESIZETERM)
+            break;
+        move(b_lines_prev, 0);
+        clrtoeol();
+        b_lines_prev = b_lines;
+    }
+    return res_key;
 }
 
 static inline void

--- a/maple/visio.c
+++ b/maple/visio.c
@@ -1687,6 +1687,7 @@ iac_process(
                 resizeterm(b_lines + 1, b_cols + 1);
 #endif
                 d_cols = b_cols - 79;
+                res_key = I_RESIZETERM;
 
                 look += 4;
             }
@@ -2633,6 +2634,8 @@ char_opt(int ch, int key, int key_timeout)
         return key_timeout;
       case I_OTHERDATA:
         return I_OTHERDATA;
+      case I_RESIZETERM:
+        return I_RESIZETERM;
       default:          /* "<sequence_until_ch> `ch`" => `key` */
         return key;
     }

--- a/maple/window.c
+++ b/maple/window.c
@@ -338,6 +338,7 @@ popupmenu_ans2(const char *const desc[], const char *title, int y_ref, int x_ref
     char hotkey;
 
     screen_backup_t old_screen;
+    screen_backup_t old_screen_dark;
 
 #ifndef M3_USE_PFTERM
     x_roll =
@@ -345,6 +346,7 @@ popupmenu_ans2(const char *const desc[], const char *title, int y_ref, int x_ref
     scr_dump(&old_screen);
 
     grayout(0, b_lines, GRAYOUT_DARK);
+    scr_dump(&old_screen_dark);
 
     hotkey = desc[0][0];
 
@@ -376,8 +378,7 @@ popupmenu_ans2_redraw:
         {
             /* Screen size changed and redraw is needed */
             /* clear */
-            scr_restore_keep(&old_screen);
-            grayout(0, b_lines, GRAYOUT_DARK);
+            scr_restore_keep(&old_screen_dark);
             goto popupmenu_ans2_redraw;
         }
 
@@ -388,6 +389,7 @@ popupmenu_ans2_redraw:
         case Meta(KEY_ESC):
         case KEY_RIGHT:
         case '\n':
+            scr_free(&old_screen_dark);
             scr_restore_free(&old_screen);
             ch = (ch == KEY_RIGHT || ch == '\n') ? desc[cur][0] : desc[0][1];
             if (ch >= 'A' && ch <= 'Z')

--- a/maple/window.c
+++ b/maple/window.c
@@ -487,9 +487,14 @@ pmsg2(const char *msg)
 #endif
     scr_dump(&old_screen);
 
-    pmsg2_body(msg);
+    for (;;)
+    {
+        pmsg2_body(msg);
+        if ((x = vkey()) != I_RESIZETERM)
+            break;
+        scr_restore_keep(&old_screen);
+    }
 
-    x = vkey();
     scr_restore_free(&old_screen);
     return x;
 }

--- a/maple/xover.c
+++ b/maple/xover.c
@@ -1659,6 +1659,7 @@ xover(
             /* XO_CUR + pos */
             if (cmd >= XO_CUR_MIN && cmd <= XO_CUR_MAX)
             {
+                xover_exec_cb(xo, XO_CUR);  /* Redraw the menu item under the cursor */
                 pos_prev = -1;  /* Suppress cursor clearing; redraw cursor */
                 cmd = XO_MOVE + XO_REL + cmd - XO_CUR;  /* Relative move */
                 continue;

--- a/maple/xover.c
+++ b/maple/xover.c
@@ -2266,7 +2266,7 @@ every_Z(XO *xo)
     memcpy(&(xz[XZ_OTHER - XO_ZONE]), &xy, sizeof(XZ));
 
     if (tmpbno >= 0)
-        XoPost(tmpbno);
+        XoPostSimple(tmpbno);
 
     utmp_mode(tmpmode);
 

--- a/maple/xover.c
+++ b/maple/xover.c
@@ -1807,6 +1807,12 @@ xover_callback_end:
         }
 
         cmd = vkey();
+        if (cmd == I_RESIZETERM)
+        {
+            cmd = XO_HEAD;
+            continue;
+        }
+
         if (!(cuser.ufo2 & UFO2_CIRCLE) && (bbsmode == M_READA))
             wrap_flag = 0;
         else

--- a/maple/xover.c
+++ b/maple/xover.c
@@ -890,7 +890,7 @@ z_download(
         waitpid(pid, &status, 0);
     else
     {
-        execl(BINARY_SUFFIX"sz", "-a", buf, NULL);
+        execl(BINARY_SUFFIX"sz", BINARY_SUFFIX"sz", "-a", buf, NULL);
         exit(0);
     }
     unlink(buf);

--- a/maple/xover.c
+++ b/maple/xover.c
@@ -2196,22 +2196,22 @@ static MENU menu_everyz[] =
     "Favorite 我的最愛"},
 #endif
 
-    {{.funcarg = {Every_Z_Xover, (const void *)XZ_GEM}}, 0, POPUP_FUN | POPUP_ARG,
+    {{.funcarg = {{Every_Z_Xover}, (const void *)XZ_GEM}}, 0, POPUP_FUN | POPUP_ARG,
     "Gem      精華區"},
 
-    {{.funcarg = {Every_Z_Xover, (const void *)XZ_ULIST}}, 0, POPUP_FUN | POPUP_ARG,
+    {{.funcarg = {{Every_Z_Xover}, (const void *)XZ_ULIST}}, 0, POPUP_FUN | POPUP_ARG,
     "Ulist    使用者名單"},
 
     {{Every_Z_Board}, 0, POPUP_FUN,
     "Post     文章列表"},
 
-    {{.funcarg = {Every_Z_Xover, (const void *)XZ_CLASS}}, 0, POPUP_FUN | POPUP_ARG,
+    {{.funcarg = {{Every_Z_Xover}, (const void *)XZ_CLASS}}, 0, POPUP_FUN | POPUP_ARG,
     "Class    看板列表"},
 
     {{Every_Z_MBox}, PERM_BASIC, POPUP_FUN,
     "Mail     信箱"},
 
-    {{.funcarg = {Every_Z_Xover, (const void *)XZ_BMW}}, 0, POPUP_FUN | POPUP_ARG,
+    {{.funcarg = {{Every_Z_Xover}, (const void *)XZ_BMW}}, 0, POPUP_FUN | POPUP_ARG,
     "Bmw      熱訊紀錄"},
 
     {{Every_Z_Screen}, 0, POPUP_FUN,
@@ -2220,7 +2220,7 @@ static MENU menu_everyz[] =
     {{NULL}, 0, POPUP_QUIT,
     "Quit     離開"},
 
-    {{.title = "快速選單"}, POPUP_DO_INSTANT + 'U', POPUP_MENUTITLE,
+    {{.title = "快速選單"}, 'U', POPUP_MENUTITLE | M_DOINSTANT,
     "快速選單切換"}
 };
 

--- a/maple/xover.c
+++ b/maple/xover.c
@@ -1488,6 +1488,8 @@ XZ xz[] =
 /* interactive menu routines                             */
 /* ----------------------------------------------------- */
 
+/* Thor.0613: 輔助訊息 */
+static int msg = 0;
 
 void
 xover(
@@ -1495,20 +1497,11 @@ xover(
 {
     int redo_flags = 0;  /* Collected redraw/reloading flags */
     int zone_flags = 0;  /* Collected zone operation flags */
-    int pos;
     int pos_prev = -1;  /* Draw cursor on entry */
     int top_prev = -1;  /* For showing the message for the last page which is full of items */
-    int wrap_flag;
-    int num=0;
     int zone=-1;
     int sysmode=0;
     XO *xo=NULL;
-    KeyFuncListRef xcmd=NULL;
-    KeyFuncIter cb;
-
-
-    /* Thor.0613: 輔助訊息 */
-    static int msg = 0;
 
     if (xo_user_level >= MAX_LEVEL)
     {
@@ -1543,9 +1536,10 @@ xover(
                 const bool scrl = cmd & XO_SCRL;
                 const bool rel = cmd & XO_REL;
                 int cur;
+                int max;
                 int diff;
 
-                pos = (cmd & XO_POS_MASK) - XO_MOVE;
+                int pos = (cmd & XO_POS_MASK) - XO_MOVE;
                 cmd = (cmd & ~XO_MOVE_MASK) + XO_NONE;
 
                 if (!xo && !zone_op)
@@ -1553,7 +1547,7 @@ xover(
 
                 /* fix cursor's range */
 
-                num = ((zone_op) ? XZ_COUNT : xo->max) - 1;
+                max = ((zone_op) ? XZ_COUNT : xo->max) - 1;
                 cur = (zone_op) ? zone : (scrl) ? xo->top : xo->pos;
 
                 if (rel)
@@ -1561,9 +1555,9 @@ xover(
                 diff = pos - cur;
 
                 if (pos < 0)
-                    pos = (wrap) ? num - (-pos-1) % BMAX(num, 1) : 0;
-                else if (pos > num)
-                    pos = (wrap) ? (pos-1) % BMAX(num, 1) : num;
+                    pos = (wrap) ? max - (-pos-1) % BMAX(max, 1) : 0;
+                else if (pos > max)
+                    pos = (wrap) ? (pos-1) % BMAX(max, 1) : max;
 
                 /* IID.20200129: Switch zone using cursor movement semantic */
                 if (zone_op)
@@ -1579,7 +1573,6 @@ xover(
                         zone = pos;
                         xo = xz[pos].xo;
                         sysmode = xz[pos].mode;
-                        xcmd = xo->cb;
 
                         TagNum = 0;             /* clear TagList */
                         pos_prev = -1;  /* Redraw cursor */
@@ -1589,7 +1582,7 @@ xover(
                         redo_flags = 0;  /* No more redraw/reloading is needed */
                     }
                     else if (rel
-                        && ((wrap && UABS(diff) <= num) || (pos > 0 && pos < num)))  /* Prevent infinity loops */
+                        && ((wrap && UABS(diff) <= max) || (pos > 0 && pos < max)))  /* Prevent infinity loops */
                     {
                         /* Fallback movement */
                         cmd = XO_ZONE + ((wrap) ? XO_WRAP : 0) + XO_REL + diff + ((diff > 0) ? 1 : -1);
@@ -1606,23 +1599,23 @@ xover(
                     if (scrl)
                     {
                         xo->top = pos;
-                        num = xo->top;
-                        xo->pos = TCLAMP(xo->pos, num, num + XO_TALL - 1);
+                        max = xo->top;
+                        xo->pos = TCLAMP(xo->pos, max, max + XO_TALL - 1);
                         cmd |= XR_BODY;      /* IID.20200103: Redraw list; do not reload. */
                     }
                     else
                     {
                         xo->pos = pos;
-                        num = xo->top;
-                        if ((pos < num) || (pos >= num + XO_TALL))
+                        max = xo->top;
+                        if ((pos < max) || (pos >= max + XO_TALL))
                         {
-                            bool scrl_up = (pos < num);
-                            xo->top = BMAX(num + ((pos - num + scrl_up) / XO_TALL - scrl_up) * XO_TALL, 0);
+                            bool scrl_up = (pos < max);
+                            xo->top = BMAX(max + ((pos - max + scrl_up) / XO_TALL - scrl_up) * XO_TALL, 0);
                             cmd |= XR_BODY;     /* IID.20200103: Redraw list; do not reload. */
                         }
                         else if (pos_prev != -1)
                         {
-                            cursor_clear(3 + cur - num, 0);
+                            cursor_clear(3 + cur - max, 0);
                             pos_prev = -1;  /* Redraw cursor */
                         }
                     }
@@ -1699,88 +1692,8 @@ xover(
             /* ----------------------------------------------- */
             /* 執行 call-back routines                         */
             /* ----------------------------------------------- */
+            cmd = xover_exec_cb(xo, cmd);
 
-            if (!xcmd)
-            {
-                /* Nothing to invoke */
-                cmd = XO_NONE;
-                continue;
-            }
-
-            /* IID.20191225: In C++ mode, use hash table for xover callback function list */
-#if !NO_SO
-            num = cmd | XO_DL; /* Thor.990220: for dynamic load */
-#endif
-#ifndef HAVE_HASH_KEYFUNCLIST  /* Callback function fetching loop */
-            cb = xcmd;
-            for (;;)
-            {
-                int (*cbfunc)(XO *xo) = NULL;
-
-                pos = cb->first;
-#endif
-#if !NO_SO
-                /* Thor.990220: dynamic load, with key | XO_DL */
-  #ifdef HAVE_HASH_KEYFUNCLIST
-                cb = xcmd->find(num);
-                if (cb != xcmd->end())
-  #else
-                if (pos == num)
-  #endif
-                {
-                    cbfunc = (int (*)(XO *xo)) DL_GET(cb->second.dlfunc);
-                    if (cbfunc)
-                    {
-  #ifdef HAVE_HASH_KEYFUNCLIST
-    #ifndef DL_HOTSWAP
-                        xcmd->erase(num);
-                        cb = xcmd->insert({cmd, {cbfunc}}).first;
-    #endif
-  #else
-    #ifndef DL_HOTSWAP
-                        cb->second.func = cbfunc;
-                        cb->first = cmd;
-    #endif
-                        pos = cmd;
-  #endif
-                    }
-                    else
-                    {
-                        cmd = XO_NONE;
-                        goto xover_callback_end;
-                    }
-                }
-#endif
-#ifdef HAVE_HASH_KEYFUNCLIST
-  #if !NO_SO
-                else
-  #endif
-                    cb = xcmd->find(cmd);
-                if (cb != xcmd->end())
-#else
-                if (pos == cmd)
-#endif
-                {
-                    if (!cbfunc)
-                        cbfunc = cb->second.func;
-                    cmd = (*cbfunc) (xo);
-                    goto xover_callback_end;
-                }
-                else  /* Callback function not found */
-#ifndef HAVE_HASH_KEYFUNCLIST
-                if (pos == 'h')
-#endif
-                {
-                    cmd = XO_NONE;
-                    goto xover_callback_end;
-                }
-
-#ifndef HAVE_HASH_KEYFUNCLIST  /* Continue callback function fetching loop */
-                cb++;
-            }
-#endif
-xover_callback_end:
-            ;
         } /* Thor.990220:註解: end of while ((cmd != XO_NONE) || redo_flags || zone_flags) */
 
         if (!xo)
@@ -1793,16 +1706,13 @@ xover_callback_end:
         utmp_mode(sysmode);
         /* Thor.990220:註解:用來回復 event handle routine 回來後的模式 */
 
-        pos = xo->pos;
-
         if (xo->max > 0)                /* Thor:若是無東西就不show了 */
         {
-            num = 3 + pos - xo->top;
-
-            if (num != pos_prev)
+            int pos_disp = 3 + xo->pos - xo->top;
+            if (pos_disp != pos_prev)
             {
-                cursor_show(num, 0);
-                pos_prev = num;
+                cursor_show(pos_disp, 0);
+                pos_prev = pos_disp;
             }
 
             if (xo->top != top_prev)
@@ -1817,242 +1727,340 @@ xover_callback_end:
         }
 
         cmd = vkey();
-        if (cmd == I_RESIZETERM)
-        {
-            cmd = XO_HEAD;
-            continue;
-        }
+        cmd = xover_key(xo, zone, cmd);
+    }
+}
 
-        if (!(cuser.ufo2 & UFO2_CIRCLE) && (bbsmode == M_READA))
-            wrap_flag = 0;
-        else
-            wrap_flag = XO_WRAP;
+int
+xover_exec_cb(
+    XO *xo,
+    int cmd)
+{
+    const KeyFuncListRef xcmd = (xo) ? xo->cb : NULL;
+    int cmd_dl;
+    KeyFuncIter cb;
 
-        /* ------------------------------------------------- */
-        /* switch Zone                                       */
-        /* ------------------------------------------------- */
-        if (cmd == Ctrl('B'))
-        {
-            every_B();
-            cmd = XO_INIT;
-            continue;
-        }
-        if (cmd == Ctrl('U') && zone != XZ_INDEX_ULIST)
-        {
-            every_U();
-            cmd = XO_INIT;
-            continue;
-        }
-        if (cmd == Ctrl('Z'))
-        {
-            every_Z();
-            cmd = XO_INIT;
-            /* cmd = XO_FOOT;*/            /* by visor : 修正 版主 bug */
-            continue;
-        }
+    if (!xcmd)
+    {
+        /* Nothing to invoke */
+        return XO_NONE;
+    }
 
-        /* ------------------------------------------------- */
-        /* 基本的游標移動 routines                           */
-        /* ------------------------------------------------- */
+    /* IID.20191225: In C++ mode, use hash table for xover callback function list */
+#if !NO_SO
+    cmd_dl = cmd | XO_DL; /* Thor.990220: for dynamic load */
+#endif
+#ifndef HAVE_HASH_KEYFUNCLIST  /* Callback function fetching loop */
+    cb = xcmd;
+    for (;;)
+    {
+        int (*cbfunc)(XO *xo) = NULL;
 
-        if (cmd == KEY_LEFT || cmd == 'e' || cmd == KEY_ESC || cmd == Meta(KEY_ESC))
+        int key = cb->first;
+#endif
+#if !NO_SO
+        /* Thor.990220: dynamic load, with key | XO_DL */
+  #ifdef HAVE_HASH_KEYFUNCLIST
+        cb = xcmd->find(cmd_dl);
+        if (cb != xcmd->end())
+  #else
+        if (key == cmd_dl)
+  #endif
         {
-            /* cmd = XO_LAST; *//* try to load the last XO in future */
-            if (zone == XZ_INDEX_MBOX)
+            cbfunc = (int (*)(XO *xo)) DL_GET(cb->second.dlfunc);
+            if (cbfunc)
             {
+  #ifdef HAVE_HASH_KEYFUNCLIST
+    #ifndef DL_HOTSWAP
+                xcmd->erase(cmd_dl);
+                cb = xcmd->insert({cmd, {p}}).first;
+    #endif
+  #else
+    #ifndef DL_HOTSWAP
+                cb->second.func = cbfunc;
+                cb->first = cmd;
+    #endif
+                key = cmd;
+  #endif
+            }
+            else
+            {
+                return XO_NONE;
+            }
+        }
+#endif
+#ifdef HAVE_HASH_KEYFUNCLIST
+  #if !NO_SO
+        else
+  #endif
+            cb = xcmd->find(cmd);
+        if (cb != xcmd->end())
+#else
+        if (key == cmd)
+#endif
+        {
+            if (!cbfunc)
+                cbfunc = cb->second.func;
+            return (*cbfunc) (xo);
+        }
+        else  /* Callback function not found */
+#ifndef HAVE_HASH_KEYFUNCLIST
+        if (key == 'h')
+#endif
+        {
+            return XO_NONE;
+        }
+
+#ifndef HAVE_HASH_KEYFUNCLIST  /* Continue callback function fetching loop */
+        cb++;
+    }
+#endif
+    /* return cmd; */ /* Unreachable */
+}
+
+int
+xover_key(
+    XO *xo,
+    int zone,
+    int cmd)
+{
+    const int pos = (xo) ? xo->pos : -1;
+    int wrap_flag;
+
+    if (!xo)
+        return XO_NONE;
+
+    if (cmd == I_RESIZETERM)
+        return XO_HEAD;
+
+    if (!(cuser.ufo2 & UFO2_CIRCLE) && (bbsmode == M_READA))
+        wrap_flag = 0;
+    else
+        wrap_flag = XO_WRAP;
+
+    /* ------------------------------------------------- */
+    /* switch Zone                                       */
+    /* ------------------------------------------------- */
+    if (cmd == Ctrl('B'))
+    {
+        every_B();
+        return XO_INIT;
+    }
+    if (cmd == Ctrl('U') && zone != XZ_INDEX_ULIST)
+    {
+        every_U();
+        return XO_INIT;
+    }
+    if (cmd == Ctrl('Z'))
+    {
+        every_Z();
+        return XO_INIT;
+        /* return XO_FOOT;*/            /* by visor : 修正 版主 bug */
+    }
+
+    /* ------------------------------------------------- */
+    /* 基本的游標移動 routines                           */
+    /* ------------------------------------------------- */
+
+    if (cmd == KEY_LEFT || cmd == 'e' || cmd == KEY_ESC || cmd == Meta(KEY_ESC))
+    {
+        /* return XO_LAST; *//* try to load the last XO in future */
+        if (zone == XZ_INDEX_MBOX)
+        {
 
 #ifdef HAVE_MAILUNDELETE
-                int deltotal;
-                char fpath[256];
+            int deltotal;
+            char fpath[256];
 
-                if ((deltotal = mbox_check()))
-                {
-                    sprintf(fpath, "有 %d 封信件將要刪除，確定嗎？ [y/N]", deltotal);
-                    if (vans(fpath) == 'y')
-                    {
-                        usr_fpath(fpath, cuser.userid, FN_DIR);
-                        hdr_prune(fpath, 0, 0, 3);
-                    }
-                }
-#endif
-                if (mail_stat(CHK_MAIL_VALID))
-                {
-                    vmsg("你的信箱容量超過上限，請整理！");
-                    chk_mailstat = 1;
-                    continue;
-                }
-                else
-                    chk_mailstat = 0;
-            }
-            xo_user_level--;
-            return;
-        }
-        else if (xo->max <= 0)  /* Thor: 無東西則無法移游標 */
-        {
-            continue;
-        }
-        else if (cmd == KEY_UP || cmd == 'p' || cmd == 'k')
-        {
-            cmd = XO_MOVE + wrap_flag + XO_REL - 1;
-        }
-        else if (cmd == KEY_DOWN || cmd == 'n' || cmd == 'j')
-        {
-            cmd = XO_MOVE + wrap_flag + XO_REL + 1;
-        }
-        else if (cmd == ' ' || cmd == KEY_PGDN || cmd == 'N'  /*|| cmd == Ctrl('F') */)
-        {                                   /* lkchu.990428: 給「暫時更改來源」用 */
-            if (pos == xo->max - 1)
+            if ((deltotal = mbox_check()))
             {
-                /* Make the cursor snap to the list bottom on screen */
-                cmd = XO_MOVE + wrap_flag + XO_REL + BMIN(xo->max, XO_TALL);
-                if (wrap_flag)
+                sprintf(fpath, "有 %d 封信件將要刪除，確定嗎？ [y/N]", deltotal);
+                if (vans(fpath) == 'y')
                 {
-                    xo->top = 0;  /* Reset list top on screen */
-                    cmd |= XR_BODY;  /* Needs to redraw */
+                    usr_fpath(fpath, cuser.userid, FN_DIR);
+                    hdr_prune(fpath, 0, 0, 3);
                 }
             }
+#endif
+            if (mail_stat(CHK_MAIL_VALID))
+            {
+                vmsg("你的信箱容量超過上限，請整理！");
+                chk_mailstat = 1;
+                return XO_FOOT;
+            }
             else
-                cmd = XO_MOVE + XO_REL + XO_TALL;  /* Stop at the last item */
+                chk_mailstat = 0;
         }
-        else if (cmd == KEY_PGUP || cmd == 'P' /*|| cmd == Ctrl('B')*/)
+        return XO_QUIT;
+    }
+    if (xo->max <= 0)  /* Thor: 無東西則無法移游標 */
+    {
+        return cmd;
+    }
+    if (cmd == KEY_UP || cmd == 'p' || cmd == 'k')
+    {
+        return XO_MOVE + wrap_flag + XO_REL - 1;
+    }
+    if (cmd == KEY_DOWN || cmd == 'n' || cmd == 'j')
+    {
+        return XO_MOVE + wrap_flag + XO_REL + 1;
+    }
+    if (cmd == ' ' || cmd == KEY_PGDN || cmd == 'N'  /*|| cmd == Ctrl('F') */)
+    {                                   /* lkchu.990428: 給「暫時更改來源」用 */
+        if (pos == xo->max - 1)
         {
-            if (pos == 0 || (xo->top != 0 && pos == xo->max - 1))
-                /* Make the cursor snap to the list top or bottom on screen */
-                cmd = XO_MOVE + wrap_flag + XO_REL - ((xo->max-1 - xo->top) % XO_TALL + 1);
-            else
-                cmd = XO_MOVE + XO_REL - XO_TALL;  /* Stop at the first item */
-        }
-        else if (cmd == KEY_HOME || cmd == '0')
-        {
-            cmd = XO_MOVE;
-        }
-        else if (cmd == KEY_END || cmd == '$')
-        {
-            cmd = XR_LOAD + XO_MOVE + XO_TAIL;  /* force re-load */
-        }
-        else if (cmd == Meta(KEY_UP) || cmd == 'K')
-        {
-            cmd = XO_MOVE + wrap_flag + XO_SCRL + XO_REL - 1;
-        }
-        else if (cmd == Meta(KEY_DOWN) || cmd == 'J')
-        {
-            cmd = XO_MOVE + wrap_flag + XO_SCRL + XO_REL + 1;
-        }
-        else if (cmd >= '1' && cmd <= '9')
-        {
-            cmd = xo_jump(cmd);
+            /* Make the cursor snap to the list bottom on screen */
+            cmd = XO_MOVE + wrap_flag + XO_REL + BMIN(xo->max, XO_TALL);
+            if (wrap_flag)
+            {
+                xo->top = 0;  /* Reset list top on screen */
+                cmd |= XR_BODY;  /* Needs to redraw */
+            }
+            return cmd;
         }
         else
-        {
-            /* ----------------------------------------------- */
-            /* keyboard mapping                                */
-            /* ----------------------------------------------- */
-
-            if (cmd == KEY_RIGHT || cmd == '\n')
-            {
-                if (zone == XZ_INDEX_ULIST)
-                    cmd = 'q'; //使用者名單會 Q
-                else
-                    cmd = 'r';
-            }
-#ifdef XZ_INDEX_XPOST
-            else if (zone >= XZ_INDEX_XPOST && zone < XZ_INDEX_BANMAIL/* XZ_INDEX_MBOX */)
-#else
-            else if (zone >= XZ_INDEX_MBOX && zone < XZ_INDEX_BANMAIL)
-#endif
-            {
-                /* --------------------------------------------- */
-                /* Tag                                           */
-                /* --------------------------------------------- */
-
-                if (cmd == 'C')
-                {
-                    cmd = xo_copy(xo);
-                }
-                else if (cmd == 'F')
-                {
-                    cmd = xo_forward(xo);
-                }
-#if 0
-                else if (cmd == 'Z')
-                {
-                    cmd = xo_zmodem(xo);
-                }
-#endif
-                else if (cmd == Ctrl('C'))
-                {
-                    if (TagNum)
-                    {
-                        TagNum = 0;
-                        cmd = XO_BODY;
-                    }
-                    else
-                        cmd = XO_NONE;
-                }
-                else if (cmd == Ctrl('A') || cmd == Ctrl('T') || cmd == Meta('T'))
-                {
-                    cmd = xo_tag(xo, cmd);
-                }
-                else if (cmd == Ctrl('D') && zone < XZ_INDEX_GEM)
-                {
-                    /* 精華區要逐一刪除, 以避免誤砍 */
-
-                    cmd = xo_prune(xo);
-                }
-                else if (cmd == 'g' && (bbstate & STAT_BOARD))
-                { /* Thor.980806: 要注意沒進看版(未定看版)時, bbstate會沒有STAT_BOARD
-                                  站長會無法收錄文章 */
-                    cmd = gem_gather(xo);               /* 收錄文章到精華區 */
-                }
-#ifdef  HAVE_MAILGEM
-                else if (cmd == 'G' && HAS_PERM(PERM_MBOX))
-                {
-                    DL_HOTSWAP_SCOPE int (*mgp)(XO *xo) = NULL;
-                    if (!mgp)
-                    {
-                        mgp = DL_NAME_GET("mailgem.so", mailgem_gather);
-                        if (mgp)
-                            cmd = (*mgp)(xo);
-                        else
-                            vmsg("動態連結失敗，請聯絡系統管理員！");
-                    }
-                    else
-                        cmd = (*mgp)(xo);
-                }
-#endif
-                /* --------------------------------------------- */
-                /* 主題式閱讀                                    */
-                /* --------------------------------------------- */
-
-#ifdef XZ_INDEX_XPOST
-                if (zone == XZ_INDEX_XPOST)
-                    continue;
-#endif
-
-                pos = xo_keymap(cmd);
-                if (pos >= 0)
-                {
-                    cmd = xo_thread(xo, pos);
-
-                    if ((cmd & XO_POS_MASK) > XO_NONE)
-                    {
-                        /* A thread article is found */
-                        cursor_clear(num, 0);
-                        cmd = (cmd & ~XO_MOVE_MASK) + XO_CUR;  /* Redraw cursor */
-                    }
-                    else
-                    {                   /* Thor.0612: 找沒有或是 已經是了, 游標不想動 */
-                        outz("\x1b[44m 找沒有了耶...:( \x1b[m");
-                        msg = 2;  /* Clear the message after the next loop */
-                    }
-                }
-            }
-            /* ----------------------------------------------- */
-            /* 其他的交給 call-back routine 去處理             */
-            /* ----------------------------------------------- */
-
-        } /* Thor.990220:註解: end of vkey() handling */
+            return XO_MOVE + XO_REL + XO_TALL;  /* Stop at the last item */
     }
+    if (cmd == KEY_PGUP || cmd == 'P' /*|| cmd == Ctrl('B')*/)
+    {
+        if (pos == 0 || (xo->top != 0 && pos == xo->max - 1))
+            /* Make the cursor snap to the list top or bottom on screen */
+            return XO_MOVE + wrap_flag + XO_REL - ((xo->max-1 - xo->top) % XO_TALL + 1);
+        else
+            return XO_MOVE + XO_REL - XO_TALL;  /* Stop at the first item */
+    }
+    if (cmd == KEY_HOME || cmd == '0')
+    {
+        return XO_MOVE;
+    }
+    if (cmd == KEY_END || cmd == '$')
+    {
+        return XR_LOAD + XO_MOVE + XO_TAIL;  /* force re-load */
+    }
+    if (cmd == Meta(KEY_UP) || cmd == 'K')
+    {
+        return XO_MOVE + wrap_flag + XO_SCRL + XO_REL - 1;
+    }
+    if (cmd == Meta(KEY_DOWN) || cmd == 'J')
+    {
+        return XO_MOVE + wrap_flag + XO_SCRL + XO_REL + 1;
+    }
+    if (cmd >= '1' && cmd <= '9')
+    {
+        return xo_jump(cmd);
+    }
+
+    /* ----------------------------------------------- */
+    /* keyboard mapping                                */
+    /* ----------------------------------------------- */
+
+    if (cmd == KEY_RIGHT || cmd == '\n')
+    {
+        if (zone == XZ_INDEX_ULIST)
+            return 'q'; //使用者名單會 Q
+        else
+            return 'r';
+    }
+#ifdef XZ_INDEX_XPOST
+    if (zone >= XZ_INDEX_XPOST && zone < XZ_INDEX_BANMAIL/* XZ_INDEX_MBOX */)
+#else
+    if (zone >= XZ_INDEX_MBOX && zone < XZ_INDEX_BANMAIL)
+#endif
+    {
+        /* --------------------------------------------- */
+        /* Tag                                           */
+        /* --------------------------------------------- */
+
+        if (cmd == 'C')
+        {
+            return xo_copy(xo);
+        }
+        if (cmd == 'F')
+        {
+            return xo_forward(xo);
+        }
+#if 0
+        if (cmd == 'Z')
+        {
+            return xo_zmodem(xo);
+        }
+#endif
+        if (cmd == Ctrl('C'))
+        {
+            if (TagNum)
+            {
+                TagNum = 0;
+                return XO_BODY;
+            }
+            return XO_NONE;
+        }
+        if (cmd == Ctrl('A') || cmd == Ctrl('T') || cmd == Meta('T'))
+        {
+            return xo_tag(xo, cmd);
+        }
+        if (cmd == Ctrl('D') && zone < XZ_INDEX_GEM)
+        {
+            /* 精華區要逐一刪除, 以避免誤砍 */
+
+            return xo_prune(xo);
+        }
+        if (cmd == 'g' && (bbstate & STAT_BOARD))
+        { /* Thor.980806: 要注意沒進看版(未定看版)時, bbstate會沒有STAT_BOARD
+                          站長會無法收錄文章 */
+            return gem_gather(xo);               /* 收錄文章到精華區 */
+        }
+#ifdef  HAVE_MAILGEM
+        if (cmd == 'G' && HAS_PERM(PERM_MBOX))
+        {
+            DL_HOTSWAP_SCOPE int (*mgp)(XO *xo) = NULL;
+            if (!mgp)
+            {
+                mgp = DL_NAME_GET("mailgem.so", mailgem_gather);
+                if (mgp)
+                    return (*mgp)(xo);
+                else
+                    vmsg("動態連結失敗，請聯絡系統管理員！");
+                return XO_FOOT;
+            }
+            else
+                return (*mgp)(xo);
+        }
+#endif
+        /* --------------------------------------------- */
+        /* 主題式閱讀                                    */
+        /* --------------------------------------------- */
+
+#ifdef XZ_INDEX_XPOST
+        if (zone == XZ_INDEX_XPOST)
+            return cmd;
+#endif
+
+        {
+            int rs_cmd = xo_keymap(cmd);
+            if (rs_cmd >= 0)
+            {
+                cmd = xo_thread(xo, rs_cmd);
+
+                if ((cmd & XO_POS_MASK) > XO_NONE)
+                {
+                    /* A thread article is found */
+                    cursor_clear(3 + pos - xo->top, 0);
+                    cmd = (cmd & ~XO_MOVE_MASK) + XO_CUR;  /* Redraw cursor */
+                }
+                else
+                {                   /* Thor.0612: 找沒有或是 已經是了, 游標不想動 */
+                    outz("\x1b[44m 找沒有了耶...:( \x1b[m");
+                    msg = 2;  /* Clear the message after the next loop */
+                }
+            }
+        }
+        return cmd;
+    }
+
+    /* ----------------------------------------------- */
+    /* 其他的交給 call-back routine 去處理             */
+    /* ----------------------------------------------- */
+    return cmd;
 }
 
 

--- a/maple/xover.c
+++ b/maple/xover.c
@@ -1620,7 +1620,7 @@ xover(
                             xo->top = BMAX(num + ((pos - num + scrl_up) / XO_TALL - scrl_up) * XO_TALL, 0);
                             cmd |= XR_BODY;     /* IID.20200103: Redraw list; do not reload. */
                         }
-                        else
+                        else if (pos_prev != -1)
                         {
                             cursor_clear(3 + cur - num, 0);
                             pos_prev = -1;  /* Redraw cursor */
@@ -1662,6 +1662,16 @@ xover(
             /* Special handling of operations                  */
             /* ----------------------------------------------- */
 
+            /* Miscellaneous commands */
+            /* XO_CUR + pos */
+            if (cmd >= XO_CUR_MIN && cmd <= XO_CUR_MAX)
+            {
+                pos_prev = -1;  /* Suppress cursor clearing; redraw cursor */
+                cmd = XO_MOVE + XO_REL + cmd - XO_CUR;  /* Relative move */
+                continue;
+            }
+
+            /* Flag commands */
             if (cmd & XZ_ZONE)
             {
                 if (cmd & XZ_QUIT)
@@ -2028,8 +2038,7 @@ xover_callback_end:
                     {
                         /* A thread article is found */
                         cursor_clear(num, 0);
-                        pos_prev = -1;  /* Redraw cursor */
-                        cmd = (cmd & ~XO_MOVE_MASK) + XO_NONE;
+                        cmd = (cmd & ~XO_MOVE_MASK) + XO_CUR;  /* Redraw cursor */
                     }
                     else
                     {                   /* Thor.0612: 找沒有或是 已經是了, 游標不想動 */

--- a/maple/xover.c
+++ b/maple/xover.c
@@ -1854,7 +1854,7 @@ xover_key(
     }
     if (cmd == Ctrl('Z'))
     {
-        every_Z();
+        every_Z(xo);
         return XO_INIT;
         /* return XO_FOOT;*/            /* by visor : ­×¥¿ ª©¥D bug */
     }
@@ -2219,7 +2219,7 @@ static MENU menu_everyz[] =
 };
 
 void
-every_Z(void)
+every_Z(XO *xo)
 {
     int tmpmode, savemode;
     int tmpbno;
@@ -2255,7 +2255,7 @@ every_Z(void)
     if (cuser.ufo2 & UFO2_ORIGUI)
         every_Z_Orig();
     else
-        popupmenu(menu_everyz, NULL, (B_LINES_REF >> 1) - 4, (D_COLS_REF >> 1) + 20);
+        popupmenu(menu_everyz, xo, (B_LINES_REF >> 1) - 4, (D_COLS_REF >> 1) + 20);
 
     memcpy(&(xz[XZ_OTHER - XO_ZONE]), &xy, sizeof(XZ));
 

--- a/maple/xover.c
+++ b/maple/xover.c
@@ -1565,33 +1565,39 @@ xover(
                     /* --------------------------------------------- */
                     /* switch zone                                   */
                     /* --------------------------------------------- */
-
-                    zone_flags |= (cmd & ~XO_MOVE_MASK);  /* Collect zone operation flags */
-
-                    if (xz[pos].xo)
+                    if (cmd & XZ_SKIN)
                     {
-                        zone = pos;
-                        xo = xz[pos].xo;
-                        sysmode = xz[pos].mode;
-
-                        TagNum = 0;             /* clear TagList */
-                        pos_prev = -1;  /* Redraw cursor */
-                        cmd = XO_INIT;
-                        utmp_mode(sysmode);
-
-                        redo_flags = 0;  /* No more redraw/reloading is needed */
-                    }
-                    else if (rel
-                        && ((wrap && UABS(diff) <= max) || (pos > 0 && pos < max)))  /* Prevent infinity loops */
-                    {
-                        /* Fallback movement */
-                        cmd = XO_ZONE + ((wrap) ? XO_WRAP : 0) + XO_REL + diff + ((diff > 0) ? 1 : -1);
-                        continue;
+                        /* TODO(IID.20200331): Change skin here */
                     }
                     else
                     {
-                        /* Switch failed; do nothing */
-                        cmd = XO_NONE;
+                        zone_flags |= (cmd & ~XO_MOVE_MASK);  /* Collect zone operation flags */
+
+                        if (xz[pos].xo)
+                        {
+                            zone = pos;
+                            xo = xz[pos].xo;
+                            sysmode = xz[pos].mode;
+
+                            TagNum = 0;             /* clear TagList */
+                            pos_prev = -1;  /* Redraw cursor */
+                            cmd = XO_INIT;
+                            utmp_mode(sysmode);
+
+                            redo_flags = 0;  /* No more redraw/reloading is needed */
+                        }
+                        else if (rel
+                            && ((wrap && UABS(diff) <= max) || (pos > 0 && pos < max)))  /* Prevent infinity loops */
+                        {
+                            /* Fallback movement */
+                            cmd = XO_ZONE + ((wrap) ? XO_WRAP : 0) + XO_REL + diff + ((diff > 0) ? 1 : -1);
+                            continue;
+                        }
+                        else
+                        {
+                            /* Switch failed; do nothing */
+                            cmd = XO_NONE;
+                        }
                     }
                 }
                 else if (pos != cur)        /* check cursor's range */

--- a/scripts/start.sh
+++ b/scripts/start.sh
@@ -1,3 +1,3 @@
-"$HOME/bin/camera"
-"$HOME/bin/acpro"
-"$HOME/bin/makefw"
+"$BBSHOME/bin$BBSVER/camera"
+"$BBSHOME/bin$BBSVER/acpro"
+"$BBSHOME/bin$BBSVER/makefw"

--- a/scripts/top.sh
+++ b/scripts/top.sh
@@ -1,5 +1,5 @@
 #!/bin/sh
 # 排行榜程式執行
 if [ "${BBSHOME}" = "" ]; then BBSHOME="/home/bbs"; fi
-"${BBSHOME}/bin/topusr" > "${BBSHOME}/gem/@/@pop.new"
+"${BBSHOME}/bin${BBSVER}/topusr" > "${BBSHOME}/gem/@/@pop.new"
 mv "${BBSHOME}/gem/@/@pop.new" "${BBSHOME}/gem/@/@pop"

--- a/so/admin.c
+++ b/so/admin.c
@@ -144,7 +144,7 @@ XO *xo)
         rec_put(xo->dir, admin, sizeof(ADMIN), pos);
         move(3 + cur, 0);
         admin_item(++pos, admin);
-        cursor_show(3 + cur, 0);
+        return XR_FOOT + XO_CUR;
     }
 
     return XO_FOOT;

--- a/so/admin.c
+++ b/so/admin.c
@@ -22,6 +22,16 @@ const ADMIN *admin)
 }
 
 static int
+admin_cur(
+XO *xo)
+{
+    const ADMIN *const admin = (const ADMIN *) xo_pool_base + xo->pos;
+    move(3 + xo->pos - xo->top, 0);
+    admin_item(xo->pos + 1, admin);
+    return XO_NONE;
+}
+
+static int
 admin_body(
 XO *xo)
 {
@@ -165,6 +175,7 @@ KeyFuncList admin_cb =
     {XO_LOAD, {admin_load}},
     {XO_HEAD, {admin_head}},
     {XO_BODY, {admin_body}},
+    {XO_CUR, {admin_cur}},
 
     {Ctrl('P'), {admin_add}},
     {'r', {admin_change}},

--- a/so/admin.c
+++ b/so/admin.c
@@ -152,8 +152,6 @@ XO *xo)
     if (memcmp(admin, &mate, sizeof(ADMIN)))
     {
         rec_put(xo->dir, admin, sizeof(ADMIN), pos);
-        move(3 + cur, 0);
-        admin_item(++pos, admin);
         return XR_FOOT + XO_CUR;
     }
 

--- a/so/adminutil.c
+++ b/so/adminutil.c
@@ -660,7 +660,7 @@ update_spammer_acl(void)
 {
     if (access(FN_ETC_SPAMMER_ACL".new", 0))
     {
-        system(BINARY_SUFFIX"clean_acl " FN_ETC_SPAMMER_ACL " " FN_ETC_SPAMMER_ACL".new");
+        PROC_CMD(BINARY_SUFFIX"clean_acl", FN_ETC_SPAMMER_ACL, FN_ETC_SPAMMER_ACL".new");
         rename(FN_ETC_SPAMMER_ACL".new", FN_ETC_SPAMMER_ACL);
     }
     else
@@ -672,7 +672,7 @@ update_untrust_acl(void)
 {
     if (access(FN_ETC_UNTRUST_ACL".new", 0))
     {
-        system(BINARY_SUFFIX"clean_acl " FN_ETC_UNTRUST_ACL " " FN_ETC_UNTRUST_ACL ".new");
+        PROC_CMD(BINARY_SUFFIX"clean_acl", FN_ETC_UNTRUST_ACL, FN_ETC_UNTRUST_ACL".new");
         rename(FN_ETC_UNTRUST_ACL".new", FN_ETC_UNTRUST_ACL);
     }
     else
@@ -879,11 +879,11 @@ const void *arg)
     switch (select)
     {
     case 1:
-        system(BINARY_SUFFIX"camera");
+        PROC_CMD(BINARY_SUFFIX"camera", NULL);
         logitfile(FN_RESET_LOG, "< 動態看板 >", NULL);
         break;
     case 2:
-        system(BINARY_SUFFIX"acpro");
+        PROC_CMD(BINARY_SUFFIX"acpro", NULL);
         board_main();
         logitfile(FN_RESET_LOG, "< 分類看板 >", NULL);
         break;
@@ -898,7 +898,7 @@ const void *arg)
         logitfile(FN_RESET_LOG, "< 異常程序 >", NULL);
         break;
     case 5:
-        system(BINARY_SUFFIX"makefw");
+        PROC_CMD(BINARY_SUFFIX"makefw", NULL);
         logitfile(FN_RESET_LOG, "< 擋信列表 >", NULL);
         break;
     case 6:
@@ -906,9 +906,9 @@ const void *arg)
         logitfile(FN_RESET_LOG, "< 主聊天室 >", NULL);
         break;
     case 7:
-        system(BINARY_SUFFIX"camera; "
-               BINARY_SUFFIX"acpro; "
-               "kill -9 `ps -auxwww | grep innbbsd | awk '{print $2}'`; "
+        PROC_CMD(BINARY_SUFFIX"camera", NULL);
+        PROC_CMD(BINARY_SUFFIX"acpro", NULL);
+        system("kill -9 `ps -auxwww | grep innbbsd | awk '{print $2}'`; "
                "kill -9 `ps -auxwww | grep bbslink | awk '{print $2}'`; "
                "kill -9 `ps -auxwww | grep bbsnnrp | awk '{print $2}'`; "
                "kill -9 `ps -auxwww | grep xchatd  | awk '{print $2}'`");

--- a/so/adminutil.c
+++ b/so/adminutil.c
@@ -47,14 +47,14 @@ m_expire(void)
     DL_HOLD;
     BRD *brd;
     char bname[16];
-    char buf[80];
 
     move(22, 0);
     outs("清除特定看板 cancel 之文章。");
     if ((brd = ask_board(bname, BRD_R_BIT, NULL)))
     {
-        sprintf(buf, BINARY_SUFFIX"expire 999 20000 20000 \"%s\" &", brd->brdname);
-        system(buf);
+        char buf[80];
+        sprintf(buf, "expire 999 20000 20000 %s", brd->brdname);
+        PROC_CMD_BG(BINARY_SUFFIX"expire", "999", "20000", "20000", brd->brdname);
         logitfile(FN_EXPIRED_LOG, cuser.userid, buf);
     }
     else
@@ -173,9 +173,7 @@ mail_to_bm(void)
         }
         else
         {
-            char command[128];
-            sprintf(command, BINARY_SUFFIX"mailtoall 2 \"%s\" \"%s\" &", fpath, title);
-            system(command);
+            PROC_CMD_BG(BINARY_SUFFIX"mailtoall", "2", fpath, title);
         }
     }
     free(bm);
@@ -274,9 +272,7 @@ mail_to_all(void)
         }
         else
         {
-            char command[128];
-            sprintf(command, BINARY_SUFFIX"mailtoall 1 \"%s\" \"%s\" &", fpath, title);
-            system(command);
+            PROC_CMD_BG(BINARY_SUFFIX"mailtoall", "1", fpath, title);
         }
     }
     return DL_RELEASE(0);
@@ -636,10 +632,8 @@ search(void)
 static void
 update_match(void)
 {
-    char fpath[128];
-    sprintf(fpath, BINARY_SUFFIX"match \"%s\" &", cuser.userid);
     if (access(FN_MATCH_NEW, 0))
-        system(fpath);
+        PROC_CMD_BG(BINARY_SUFFIX"match", cuser.userid);
     else
         vmsg("正在工作中");
 }
@@ -647,10 +641,8 @@ update_match(void)
 static void
 update_email(void)
 {
-    char fpath[128];
-    sprintf(fpath, BINARY_SUFFIX"checkemail \"%s\" &", cuser.userid);
     if (access(FN_ETC_EMAILADDR_ACL".new", 0))
-        system(fpath);
+        PROC_CMD_BG(BINARY_SUFFIX"checkemail", cuser.userid);
     else
         vmsg("正在工作中");
 }

--- a/so/aloha.c
+++ b/so/aloha.c
@@ -63,6 +63,16 @@ const ALOHA *aloha)
 }
 
 static int
+aloha_cur(
+XO *xo)
+{
+    const ALOHA *const aloha = (const ALOHA *) xo_pool_base + xo->pos;
+    move(3 + xo->pos - xo->top, 0);
+    aloha_item(xo->pos + 1, aloha);
+    return XO_NONE;
+}
+
+static int
 aloha_body(
 XO *xo)
 {
@@ -291,6 +301,7 @@ KeyFuncList aloha_cb =
     {XO_LOAD, {aloha_load}},
     {XO_HEAD, {aloha_head}},
     {XO_BODY, {aloha_body}},
+    {XO_CUR, {aloha_cur}},
 
     {'a', {aloha_add}},
     {'D', {aloha_rangedel}},

--- a/so/brdstat.c
+++ b/so/brdstat.c
@@ -22,6 +22,16 @@ const BSTAT *bstat)
 }
 
 static int
+bstat_cur(
+XO *xo)
+{
+    const BSTAT *const bstat = (const BSTAT *) xo_pool_base + xo->pos;
+    move(3 + xo->pos - xo->top, 0);
+    bstat_item(xo->pos + 1, bstat);
+    return XO_NONE;
+}
+
+static int
 bstat_body(
 XO *xo)
 {
@@ -152,6 +162,7 @@ KeyFuncList bstat_cb =
     {XO_LOAD, {bstat_load}},
     {XO_HEAD, {bstat_head}},
     {XO_BODY, {bstat_body}},
+    {XO_CUR, {bstat_cur}},
 
     {'s', {xo_cb_init}},
     {'S', {bstat_stat}},

--- a/so/chat.c
+++ b/so/chat.c
@@ -881,7 +881,7 @@ t_chat(void)
             /* Thor.0727: º»¶s vio_fd */
             holdon_fd = vio_fd;
             vio_fd = 0;
-            every_Z();
+            every_Z(NULL);
             /* Thor.0727: ¡Ÿ≠Ï vio_fd */
             vio_fd = holdon_fd;
             holdon_fd = 0;

--- a/so/chatmenu.c
+++ b/so/chatmenu.c
@@ -181,8 +181,6 @@ XO *xo)
     if (memcmp(chat, &mate, sizeof(ChatAction)))
     {
         rec_put(xo->dir, chat, sizeof(ChatAction), pos);
-        move(3 + cur, 0);
-        chat_item(++pos, chat);
         return XR_FOOT + XO_CUR;
     }
 

--- a/so/chatmenu.c
+++ b/so/chatmenu.c
@@ -173,7 +173,7 @@ XO *xo)
         rec_put(xo->dir, chat, sizeof(ChatAction), pos);
         move(3 + cur, 0);
         chat_item(++pos, chat);
-        cursor_show(3 + cur, 0);
+        return XR_FOOT + XO_CUR;
     }
 
     return XO_FOOT;

--- a/so/chatmenu.c
+++ b/so/chatmenu.c
@@ -26,6 +26,16 @@ const ChatAction *chat)
 }
 
 static int
+chat_cur(
+XO *xo)
+{
+    const ChatAction *const chat = (const ChatAction *) xo_pool_base + xo->pos;
+    move(3 + xo->pos - xo->top, 0);
+    chat_item(xo->pos + 1, chat);
+    return XO_NONE;
+}
+
+static int
 chat_body(
 XO *xo)
 {
@@ -259,6 +269,7 @@ KeyFuncList chat_cb =
     {XO_LOAD, {chat_load}},
     {XO_HEAD, {chat_head}},
     {XO_BODY, {chat_body}},
+    {XO_CUR, {chat_cur}},
 
     {Ctrl('P'), {chat_add}},
     {'a', {chat_add}},

--- a/so/cleanrecommend.c
+++ b/so/cleanrecommend.c
@@ -80,6 +80,16 @@ cleanrecommend_item(
 }
 
 static int
+cleanrecommend_cur(
+    XO *xo)
+{
+    const RMSG *const cleanrecommend = (const RMSG *) xo_pool_base + xo->pos;
+    move(3 + xo->pos - xo->top, 0);
+    cleanrecommend_item(xo->pos + 1, cleanrecommend);
+    return XO_NONE;
+}
+
+static int
 cleanrecommend_body(
     XO *xo)
 {
@@ -234,6 +244,7 @@ KeyFuncList cleanrecommend_cb =
     {XO_LOAD, {cleanrecommend_load}},
     {XO_HEAD, {cleanrecommend_head}},
     {XO_BODY, {cleanrecommend_body}},
+    {XO_CUR, {cleanrecommend_cur}},
 
     {'c', {cleanrecommend_change}},
     {'s', {xo_cb_init}},

--- a/so/cleanrecommend.c
+++ b/so/cleanrecommend.c
@@ -201,7 +201,7 @@ cleanrecommend_change(
         rec_put(xo->dir, cleanrecommend, sizeof(RMSG), pos);
         move(3 + cur, 0);
         cleanrecommend_item(++pos, cleanrecommend);
-        cursor_show(3 + cur, 0);
+        return XR_FOOT + XO_CUR;
     }
 
     return XO_FOOT;

--- a/so/cleanrecommend.c
+++ b/so/cleanrecommend.c
@@ -209,8 +209,6 @@ cleanrecommend_change(
     if (memcmp(cleanrecommend, &mate, sizeof(RMSG)))
     {
         rec_put(xo->dir, cleanrecommend, sizeof(RMSG), pos);
-        move(3 + cur, 0);
-        cleanrecommend_item(++pos, cleanrecommend);
         return XR_FOOT + XO_CUR;
     }
 

--- a/so/contact.c
+++ b/so/contact.c
@@ -22,6 +22,16 @@ const CONTACT *contact)
 }
 
 static int
+contact_cur(
+XO *xo)
+{
+    const CONTACT *const contact = (const CONTACT *) xo_pool_base + xo->pos;
+    move(3 + xo->pos - xo->top, 0);
+    contact_item(xo->pos + 1, contact);
+    return XO_NONE;
+}
+
+static int
 contact_body(
 XO *xo)
 {
@@ -221,6 +231,7 @@ KeyFuncList contact_cb =
     {XO_LOAD, {contact_load}},
     {XO_HEAD, {contact_head}},
     {XO_BODY, {contact_body}},
+    {XO_CUR, {contact_cur}},
 
     {Ctrl('P'), {contact_add}},
     {'m', {contact_mail}},

--- a/so/contact.c
+++ b/so/contact.c
@@ -146,7 +146,7 @@ XO *xo)
         rec_put(xo->dir, contact, sizeof(CONTACT), pos);
         move(3 + cur, 0);
         contact_item(++pos, contact);
-        cursor_show(3 + cur, 0);
+        return XR_FOOT + XO_CUR;
     }
 
     return XO_FOOT;

--- a/so/contact.c
+++ b/so/contact.c
@@ -154,8 +154,6 @@ XO *xo)
     if (memcmp(contact, &mate, sizeof(CONTACT)))
     {
         rec_put(xo->dir, contact, sizeof(CONTACT), pos);
-        move(3 + cur, 0);
-        contact_item(++pos, contact);
         return XR_FOOT + XO_CUR;
     }
 

--- a/so/innbbs.c
+++ b/so/innbbs.c
@@ -535,6 +535,17 @@ innbbs_foot(
 }
 
 static int
+innbbs_cur(
+    XO *xo)
+{
+    InnbbsXyz *const xyz = (InnbbsXyz *)xo->xyz;
+    const char *const rec = xo_pool_base + xo->pos * xo->recsiz;
+    move(3 + xo->pos - xo->top, 0);
+    xyz->item_func(xo->pos + 1, rec);
+    return XO_NONE;
+}
+
+static int
 innbbs_body(
     XO *xo)
 {
@@ -683,6 +694,7 @@ static KeyFuncList innbbs_cb =
     {XO_HEAD, {innbbs_head}},
     {XO_BODY, {innbbs_body}},
     {XO_FOOT, {innbbs_foot}},
+    {XO_CUR, {innbbs_cur}},
 
 
     {' ', {innbbs_query}},

--- a/so/list.c
+++ b/so/list.c
@@ -26,6 +26,16 @@ const LIST *list)
 }
 
 static int
+list_cur(
+XO *xo)
+{
+    const LIST *const list = (const LIST *) xo_pool_base + xo->pos;
+    move(3 + xo->pos - xo->top, 0);
+    list_item(xo->pos + 1, list);
+    return XO_NONE;
+}
+
+static int
 list_body(
 XO *xo)
 {
@@ -295,6 +305,7 @@ KeyFuncList list_cb =
     {XO_LOAD, {list_load}},
     {XO_HEAD, {list_head}},
     {XO_BODY, {list_body}},
+    {XO_CUR, {list_cur}},
 
     {'r', {list_browse}},
     {'T', {list_title}},

--- a/so/mailgem.c
+++ b/so/mailgem.c
@@ -295,7 +295,7 @@ XO *xo)
         num++;
         move(num - xo->top + 2, 0);
         mailgem_item(num, ghdr);
-        cursor_show(num - xo->top + 2, 0);
+        return XR_FOOT + XO_CUR;
 
     }
     return XO_FOOT;
@@ -845,7 +845,7 @@ XO *xo)
     {
         move(3 + pos - xo->top, 0);
         mailgem_item(pos + 1, ghdr);
-        cursor_show(3 + pos - xo->top, 0);
+        return XO_CUR + 1;
     }
 
     return XO_MOVE + XO_REL + 1;

--- a/so/mailgem.c
+++ b/so/mailgem.c
@@ -301,9 +301,6 @@ XO *xo)
         *ghdr = xhdr;
         num = xo->pos;
         rec_put(dir, ghdr, sizeof(HDR), num);
-        num++;
-        move(num - xo->top + 2, 0);
-        mailgem_item(num, ghdr);
         return XR_FOOT + XO_CUR;
 
     }
@@ -852,8 +849,6 @@ XO *xo)
 
     if ((tag = Tagger(ghdr->chrono, pos, TAG_TOGGLE)))
     {
-        move(3 + pos - xo->top, 0);
-        mailgem_item(pos + 1, ghdr);
         return XO_CUR + 1;
     }
 

--- a/so/mailgem.c
+++ b/so/mailgem.c
@@ -52,6 +52,15 @@ const HDR *ghdr)
            (gtype == 1 ? ghdr->xname : ghdr->owner), ghdr->date);
 }
 
+static int
+mailgem_cur(
+XO *xo)
+{
+    const HDR *const ghdr = (const HDR *) xo_pool_base + xo->pos;
+    move(3 + xo->pos - xo->top, 0);
+    mailgem_item(xo->pos + 1, ghdr);
+    return XO_NONE;
+}
 
 static int
 mailgem_body(
@@ -998,6 +1007,7 @@ static KeyFuncList mailgem_cb =
     {XO_HEAD, {mailgem_head}},
     {XO_BODY, {mailgem_body}},
     {XO_FOOT, {mailgem_foot}},
+    {XO_CUR, {mailgem_cur}},
 
     {'r', {mailgem_browse}},
 

--- a/so/memorandum.c
+++ b/so/memorandum.c
@@ -211,7 +211,7 @@ XO *xo)
         rec_put(xo->dir, memorandum, sizeof(MEMORANDUM), pos);
         move(3 + cur, 0);
         memorandum_item(++pos, memorandum);
-        cursor_show(3 + cur, 0);
+        return XR_FOOT + XO_CUR;
     }
 
     return XO_FOOT;

--- a/so/memorandum.c
+++ b/so/memorandum.c
@@ -86,6 +86,16 @@ const MEMORANDUM *memorandum)
 }
 
 static int
+memorandum_cur(
+XO *xo)
+{
+    const MEMORANDUM *const memorandum = (const MEMORANDUM *) xo_pool_base + xo->pos;
+    move(3 + xo->pos - xo->top, 0);
+    memorandum_item(xo->pos + 1, memorandum);
+    return XO_NONE;
+}
+
+static int
 memorandum_body(
 XO *xo)
 {
@@ -231,6 +241,7 @@ KeyFuncList memorandum_cb =
     {XO_LOAD, {memorandum_load}},
     {XO_HEAD, {memorandum_head}},
     {XO_BODY, {memorandum_body}},
+    {XO_CUR, {memorandum_cur}},
 
     {Ctrl('P'), {memorandum_add}},
     {'r', {memorandum_change}},

--- a/so/memorandum.c
+++ b/so/memorandum.c
@@ -219,8 +219,6 @@ XO *xo)
     if (memcmp(memorandum, &mate, sizeof(MEMORANDUM)))
     {
         rec_put(xo->dir, memorandum, sizeof(MEMORANDUM), pos);
-        move(3 + cur, 0);
-        memorandum_item(++pos, memorandum);
         return XR_FOOT + XO_CUR;
     }
 

--- a/so/newboard.c
+++ b/so/newboard.c
@@ -129,6 +129,16 @@ const NBRD *nbrd)
         prints("%6d %c %-5s %-13s %-*.*s\n", num, nbrd_attr(nbrd), nbrd->date + 3, nbrd->owner, d_cols + 50, d_cols + 50, nbrd->title);
 }
 
+static int
+nbrd_cur(
+XO *xo)
+{
+    const NBRD *const nbrd = (const NBRD *) xo_pool_base + xo->pos;
+    move(3 + xo->pos - xo->top, 0);
+    nbrd_item(xo->pos + 1, nbrd);
+    return XO_NONE;
+}
+
 
 static int
 nbrd_body(
@@ -915,6 +925,7 @@ KeyFuncList nbrd_cb =
     {XO_LOAD, {nbrd_load}},
     {XO_HEAD, {nbrd_head}},
     {XO_BODY, {nbrd_body}},
+    {XO_CUR, {nbrd_cur}},
 
     {'j', {nbrd_join}},
     {'r', {nbrd_browse}},

--- a/so/observe.c
+++ b/so/observe.c
@@ -236,7 +236,7 @@ XO *xo)
         rec_put(xo->dir, observe, sizeof(OBSERVE), pos);
         move(3 + cur, 0);
         observe_item(++pos, observe);
-        cursor_show(3 + cur, 0);
+        return XR_FOOT + XO_CUR;
     }
 
     return XO_FOOT;

--- a/so/observe.c
+++ b/so/observe.c
@@ -244,8 +244,6 @@ XO *xo)
     if (memcmp(observe, &mate, sizeof(OBSERVE)))
     {
         rec_put(xo->dir, observe, sizeof(OBSERVE), pos);
-        move(3 + cur, 0);
-        observe_item(++pos, observe);
         return XR_FOOT + XO_CUR;
     }
 

--- a/so/observe.c
+++ b/so/observe.c
@@ -28,6 +28,16 @@ const OBSERVE *observe)
 }
 
 static int
+observe_cur(
+XO *xo)
+{
+    const OBSERVE *const observe = (const OBSERVE *) xo_pool_base + xo->pos;
+    move(3 + xo->pos - xo->top, 0);
+    observe_item(xo->pos + 1, observe);
+    return XO_NONE;
+}
+
+static int
 observe_body(
 XO *xo)
 {
@@ -257,6 +267,7 @@ KeyFuncList observe_cb =
     {XO_LOAD, {observe_load}},
     {XO_HEAD, {observe_head}},
     {XO_BODY, {observe_body}},
+    {XO_CUR, {observe_cur}},
 
     {Ctrl('P'), {observe_add}},
     {'S', {observe_sync}},

--- a/so/personal.c
+++ b/so/personal.c
@@ -245,6 +245,16 @@ personal_item(
 }
 
 static int
+personal_cur(
+    XO *xo)
+{
+    const PB *const personal = (const PB *) xo_pool_base + xo->pos;
+    move(3 + xo->pos - xo->top, 0);
+    personal_item(xo->pos + 1, personal);
+    return XO_NONE;
+}
+
+static int
 personal_body(
     XO *xo)
 {
@@ -611,6 +621,7 @@ KeyFuncList personal_cb =
     {XO_LOAD, {personal_load}},
     {XO_HEAD, {personal_head}},
     {XO_BODY, {personal_body}},
+    {XO_CUR, {personal_cur}},
 
     {'c', {personal_change}},
     {'s', {xo_cb_init}},

--- a/so/personal.c
+++ b/so/personal.c
@@ -356,7 +356,7 @@ personal_change(
         rec_put(xo->dir, personal, sizeof(PB), pos);
         move(3 + cur, 0);
         personal_item(++pos, personal);
-        cursor_show(3 + cur, 0);
+        return XR_FOOT + XO_CUR;
     }
 
     return XO_FOOT;

--- a/so/personal.c
+++ b/so/personal.c
@@ -364,8 +364,6 @@ personal_change(
     if (memcmp(personal, &mate, sizeof(PB)))
     {
         rec_put(xo->dir, personal, sizeof(PB), pos);
-        move(3 + cur, 0);
-        personal_item(++pos, personal);
         return XR_FOOT + XO_CUR;
     }
 

--- a/so/pip.c
+++ b/so/pip.c
@@ -1622,8 +1622,8 @@ pip_write_backup(void)
     clrtobot();
     sprintf(buf1, "儲存 [%s] 檔案完成了", files[num - 1]);
     vmsg(buf1);
-    sprintf(buf, "/bin/cp %s %s.bak%d", get_path(cuser.userid, "chicken"), get_path(cuser.userid, "chicken"), num);
-    system(buf);
+    sprintf(buf, "%s%d", get_path(cuser.userid, "chicken.bak"), num);
+    PROC_CMD("/bin/cp", get_path(cuser.userid, "chicken"), buf);
     return 0;
 }
 
@@ -1686,10 +1686,9 @@ pip_read_backup(void)
     sprintf(buf, "讀取 [%s] 檔案完成了", files[num - 1]);
     vmsg(buf);
 
-    sprintf(buf1, "/bin/touch %s%d", get_path(cuser.userid, "chicken.bak"), num);
-    sprintf(buf2, "/bin/cp %s.bak%d %s", get_path(cuser.userid, "chicken"), num, get_path(cuser.userid, "chicken"));
-    system(buf1);
-    system(buf2);
+    sprintf(buf1, "%s%d", get_path(cuser.userid, "chicken.bak"), num);
+    PROC_CMD("/bin/touch", buf1);
+    PROC_CMD("/bin/cp", buf1, get_path(cuser.userid, "chicken"));
     pip_read_file(&d, cuser.userid);
     return 0;
 }
@@ -5097,8 +5096,7 @@ pip_ending_screen(void)
     endgrade = pip_game_over(endgrade);
     /* inmoney(endgrade*10*ba);
       inexp(endgrade*ba);*/
-    sprintf(buf, "/bin/rm %s", get_path(cuser.userid, "chicken"));
-    system(buf);
+    PROC_CMD("/bin/rm", get_path(cuser.userid, "chicken"));
     sprintf(buf, "得到 %d 元，%d 點經驗值", endgrade*10*ba, endgrade*10);
     vmsg(buf);
     vmsg("下一頁是小雞資料  趕快copy下來作紀念");

--- a/so/showvote.c
+++ b/so/showvote.c
@@ -155,8 +155,6 @@ XO *xo)
     if (memcmp(show, &mate, sizeof(LOG)))
     {
         rec_put(xo->dir, show, sizeof(LOG), pos);
-        move(3 + cur, 0);
-        show_item(++pos, show);
         return XR_FOOT + XO_CUR;
     }
 

--- a/so/showvote.c
+++ b/so/showvote.c
@@ -25,6 +25,16 @@ const LOG *show)
 }
 
 static int
+show_cur(
+XO *xo)
+{
+    const LOG *const show = (const LOG *) xo_pool_base + xo->pos;
+    move(3 + xo->pos - xo->top, 0);
+    show_item(xo->pos + 1, show);
+    return XO_NONE;
+}
+
+static int
 show_body(
 XO *xo)
 {
@@ -167,6 +177,7 @@ KeyFuncList show_cb =
     {XO_LOAD, {show_load}},
     {XO_HEAD, {show_head}},
     {XO_BODY, {show_body}},
+    {XO_CUR, {show_cur}},
 
     {Ctrl('P'), {show_add}},
     {'r', {show_change}},

--- a/so/showvote.c
+++ b/so/showvote.c
@@ -147,7 +147,7 @@ XO *xo)
         rec_put(xo->dir, show, sizeof(LOG), pos);
         move(3 + cur, 0);
         show_item(++pos, show);
-        cursor_show(3 + cur, 0);
+        return XR_FOOT + XO_CUR;
     }
 
     return XO_FOOT;

--- a/so/song.c
+++ b/so/song.c
@@ -541,7 +541,7 @@ XO *xo)
         num++;
         move(num - xo->top + 2, 0);
         song_item(num, ghdr);
-        cursor_show(num - xo->top + 2, 0);
+        return XR_FOOT + XO_CUR;
 
     }
     return XO_FOOT;

--- a/so/song.c
+++ b/so/song.c
@@ -158,6 +158,16 @@ const HDR *ghdr)
         prints("%-.*s\n", d_cols + 68, ghdr->title);
 }
 
+static int
+song_cur(
+XO *xo)
+{
+    const HDR *const ghdr = (const HDR *) xo_pool_base + xo->pos;
+    move(3 + xo->pos - xo->top, 0);
+    song_item(xo->pos + 1, ghdr);
+    return XO_NONE;
+}
+
 
 static int
 song_body(
@@ -562,6 +572,7 @@ static KeyFuncList song_cb =
     {XO_HEAD, {song_head}},
     {XO_BODY, {song_body}},
     {XO_FOOT, {song_foot}},
+    {XO_CUR, {song_cur}},
 
     {'r', {song_browse}},
     {'o', {song_order}},

--- a/so/song.c
+++ b/so/song.c
@@ -652,8 +652,8 @@ AddRequestTimes(void)
 {
     DL_HOLD;
     ACCT acct;
-    char buf[128];
-    int n, times;
+    char buf[5];
+    int n;
 
     if (!vget(B_LINES_REF, 0, "請選擇：1)增加單人 2)條件增加 0)取消 [0]", buf, 3, DOECHO))
         return DL_RELEASE(0);
@@ -673,14 +673,14 @@ AddRequestTimes(void)
     }
     else if (*buf == '2')
     {
+        char buf_n[12];
         n = 0;
         n = bitset(n, NUMPERMS, NUMPERMS, MSG_USERPERM, perm_tbl);
         if (!vget(B_LINES_REF, 0, "加幾次：", buf, 5, DOECHO))
             return DL_RELEASE(0);
-        times = atoi(buf);
-        sprintf(buf, BINARY_SUFFIX"addsong %d %d &", n, times);
+        sprintf(buf_n, "%u", n);
         if (vans("確定增加嗎？ [y/N]") == 'y')
-            system(buf);
+            PROC_CMD_BG(BINARY_SUFFIX"addsong", buf_n, buf);
     }
     return DL_RELEASE(0);
 }

--- a/so/song.c
+++ b/so/song.c
@@ -548,9 +548,6 @@ XO *xo)
         *ghdr = xhdr;
         num = xo->pos;
         rec_put(dir, ghdr, sizeof(HDR), num);
-        num++;
-        move(num - xo->top + 2, 0);
-        song_item(num, ghdr);
         return XR_FOOT + XO_CUR;
 
     }

--- a/so/violate.c
+++ b/so/violate.c
@@ -152,7 +152,7 @@ XO *xo)
         rec_put(xo->dir, viol, sizeof(EMAIL), pos);
         move(3 + cur, 0);
         viol_item(++pos, viol);
-        cursor_show(3 + cur, 0);
+        return XR_FOOT + XO_CUR;
     }
 
     return XO_FOOT;

--- a/so/violate.c
+++ b/so/violate.c
@@ -160,8 +160,6 @@ XO *xo)
     if (memcmp(viol, &mate, sizeof(EMAIL)))
     {
         rec_put(xo->dir, viol, sizeof(EMAIL), pos);
-        move(3 + cur, 0);
-        viol_item(++pos, viol);
         return XR_FOOT + XO_CUR;
     }
 

--- a/so/violate.c
+++ b/so/violate.c
@@ -30,6 +30,16 @@ const EMAIL *viol)
 }
 
 static int
+viol_cur(
+XO *xo)
+{
+    const EMAIL *const viol = (const EMAIL *) xo_pool_base + xo->pos;
+    move(3 + xo->pos - xo->top, 0);
+    viol_item(xo->pos + 1, viol);
+    return XO_NONE;
+}
+
+static int
 viol_body(
 XO *xo)
 {
@@ -212,6 +222,7 @@ KeyFuncList viol_cb =
     {XO_LOAD, {viol_load}},
     {XO_HEAD, {viol_head}},
     {XO_BODY, {viol_body}},
+    {XO_CUR, {viol_cur}},
 
     {Ctrl('P'), {viol_add}},
     {'r', {viol_change}},

--- a/so/vote.c
+++ b/so/vote.c
@@ -98,6 +98,16 @@ const VCH *vch)
            num, vch->cdate, vch->owner, d_cols + 50, d_cols + 50, vch->title);
 }
 
+static int
+vote_cur(
+XO *xo)
+{
+    const VCH *const vch = (const VCH *) xo_pool_base + xo->pos;
+    move(3 + xo->pos - xo->top, 0);
+    vote_item(xo->pos + 1, vch);
+    return XO_NONE;
+}
+
 
 static int
 vote_body(
@@ -1109,6 +1119,7 @@ static KeyFuncList vote_cb =
     {XO_LOAD, {vote_load}},
     {XO_HEAD, {vote_head}},
     {XO_BODY, {vote_body}},
+    {XO_CUR, {vote_cur}},
 
     {'r', {vote_join}},
     {'v', {vote_join}},

--- a/util/account.c
+++ b/util/account.c
@@ -443,10 +443,10 @@ gzip(
 {
     char buf[128];
 
-    sprintf(buf, "`which gzip` -n log/%s%s", target, stamp);
-    /* rename(source, &buf[13]); */
-    f_mv(source, &buf[17]); /* Thor.990409: 可跨 partition */
-    system(buf);
+    sprintf(buf, "log/%s%s", target, stamp);
+    /* rename(source, buf); */
+    f_mv(source, &buf[4]); /* Thor.990409: 可跨 partition */
+    PROC_CMD("/bin/gzip", "-n", buf);
 }
 
 
@@ -458,8 +458,8 @@ gtar(
 {
     char buf[128];
 
-    sprintf(buf, "`which tar` cfz log/%s%s.tgz %s", target, stamp, source);
-    system(buf);
+    sprintf(buf, "log/%s%s.tgz", target, stamp);
+    PROC_CMD("/bin/tar", "cfz", buf, source);
 
     if (prune)
     {
@@ -527,8 +527,7 @@ main(void)
 
     if (rename(run_file, tmp_file))
     {
-        sprintf(buf, "touch %s", tmp_file);
-        system(buf);
+        PROC_CMD("bin/touch", tmp_file);
     }
     if ((fp = fopen(tmp_file, "r")) == NULL)
         error(tmp_file);
@@ -653,11 +652,11 @@ main(void)
         /* 以下是目前沒有在使用的紀錄 */
 
 //        sprintf(title, "[記錄] %s使用次數統計", date);
-//        system(BINARY_SUFFIX"spss.sh");
+//        PROC_CMD("bin/sh", BINARY_SUFFIX"spss.sh");
 //        keeplog("run/spss.log", NULL, title, 2);
 
 //        sprintf(title, "[記錄] %s版面閱\讀次數統計", date);
-//        system(BINARY_SUFFIX"brd_usies.sh");
+//        PROC_CMD("bin/sh", BINARY_SUFFIX"brd_usies.sh");
 //        keeplog(FN_BRD_USIES".log", NULL, title, 2); /* 整理過後的 log */
 //        keeplog(FN_BRD_USIES, BRD_SECRET, title, 2); /* 未整理前的 log */
 //        gzip(FN_BRD_USIES, "brdusies/brdusies", ymd);   /* 未整理前的 log */
@@ -843,7 +842,7 @@ main(void)
         sprintf(date, "[%02d 月 %02d 日] ", ptime.tm_mon + 1, ptime.tm_mday);
 
         sprintf(title, "[記錄] %s使用者編號紀錄", date);
-        system(BINARY_SUFFIX"userno");
+        PROC_CMD(BINARY_SUFFIX"userno", NULL);
         keeplog(FN_USERNO_LOG, BRD_SECRET, title, 2);
         gzip(FN_USERNO_LOG, "userno/userno", ymd);        /* 所有 [使用者編號紀錄] 記錄 */
         gzip(FN_MAIL_LOG, "mail/mail", ymd);    /* 所有 [寄信] 記錄 */

--- a/util/backup.c
+++ b/util/backup.c
@@ -61,8 +61,8 @@ proceed(
         if (fname[0] > ' ' && fname[0] != '.')
         {
             //strcpy(str, fname);
-            sprintf(cmd, "tar zcf %s/usr/usr%02d%02d/%c/%s.tgz %s", bk_path, mon, mday, *fname, fname, fname);
-            system(cmd);
+            sprintf(cmd, "%s/usr/usr%02d%02d/%c/%s.tgz", bk_path, mon, mday, *fname, fname);
+            PROC_CMD("/bin/tar", "zcf", cmd, fname);
         }
     }
     closedir(dirp);
@@ -138,8 +138,8 @@ bk_brd(
             if ((day == 4 && ((ptr[0] >= '0' && ptr[0] <= '9') || (ptr[0] >= 'a' && ptr[0] <= 'k') || (ptr[0] >= 'A' && ptr[0] <= 'K'))) ||
                 (day == 5 && ((ptr[0] >= 'l' && ptr[0] <= 'z') || (ptr[0] >= 'L' && ptr[0] <= 'Z'))))
             {
-                sprintf(cmd, "tar zvcf %s/brd/brd%02d%02d/%s.tgz %s", bk_path, mon, mday, ptr, ptr);
-                system(cmd);
+                sprintf(cmd, "%s/brd/brd%02d%02d/%s.tgz", bk_path, mon, mday, ptr);
+                PROC_CMD("/bin/tar", "zvcf", cmd, ptr);
             }
             else
                 continue;
@@ -176,8 +176,8 @@ bk_gem(void)
 
         if (ptr[0] > ' ' && ptr[0] != '.')
         {
-            sprintf(cmd, "tar zcf %s/gem/gem%02d%02d/%s.tgz %s", bk_path, mon, mday, ptr, ptr);
-            system(cmd);
+            sprintf(cmd, "%s/gem/gem%02d%02d/%s.tgz", bk_path, mon, mday, ptr);
+            PROC_CMD("/bin/tar", "zcf", cmd, ptr);
         }
     }
     closedir(dirp);
@@ -206,31 +206,29 @@ bk_system_src(void)
 
     for (i=0; i < COUNTOF(system_folders); i++)
     {
-        sprintf(cmd, "tar zcf %s/%s.tgz %s", path, system_folders[i], system_folders[i]);
-        system(cmd);
+        sprintf(cmd, "%s/%s.tgz", path, system_folders[i]);
+        PROC_CMD("/bin/tar", "zcf", cmd, system_folders[i]);
     }
 
-    sprintf(cmd, "touch %s/gem.tar", path);
-    system(cmd);
-    sprintf(cmd, "tar rvf %s/gem.tar gem/.DIR", path);
-    system(cmd);
-    sprintf(cmd, "tar rvf %s/gem.tar gem/.GEM", path);
-    system(cmd);
+    sprintf(cmd, "%s/gem.tar", path);
+    PROC_CMD("/bin/touch", cmd);
+    PROC_CMD("/bin/tar", "rvf", cmd, "gem/.DIR");
+    PROC_CMD("/bin/tar", "rvf", cmd, "gem/.GEM");
     for (i = '0'; i <= '9'; i++)
     {
-        sprintf(cmd, "tar rvf %s/gem.tar gem/%c", path, i);
-        system(cmd);
+        char path_i[6];
+        sprintf(path_i, "gem/%c", i);
+        PROC_CMD("/bin/tar", "rvf", cmd, path_i);
     }
     for (i = 'A'; i <= 'V'; i++)
     {
-        sprintf(cmd, "tar rvf %s/gem.tar gem/%c", path, i);
-        system(cmd);
+        char path_i[6];
+        sprintf(path_i, "gem/%c", i);
+        PROC_CMD("/bin/tar", "rvf", cmd, path_i);
     }
-    sprintf(cmd, "tar rvf %s/gem.tar gem/@", path);
-    system(cmd);
+    PROC_CMD("/bin/tar", "rvf", cmd, "gem/@");
 
-    sprintf(cmd, "gzip -9 %s/gem.tar", path);
-    system(cmd);
+    PROC_CMD("/bin/gzip", "-9", cmd);
 
     log_backup("system backup complete");
 

--- a/util/brdcheck.c
+++ b/util/brdcheck.c
@@ -30,7 +30,7 @@ main(
     for (c = 'a'; c <= 'z'; c++)
     {
         char buf[64];
-        GCC_UNUSED char buf2[64];
+        GCC_UNUSED char buf2[64], buf3[64];
         struct dirent *de;
         DIR *dirp;
 
@@ -56,8 +56,9 @@ main(
             if ((fd = open(buf, O_RDONLY)) < 0)
             {
                 printf("brd/%s is missing, cp DIR.o\n", buf);
-                //sprintf(buf2, "cp %s/.DIR.o %s/.DIR", str, str);
-                //system(buf2);
+                //sprintf(buf2, "%s/.DIR.o", str);
+                //sprintf(buf3, "%s/.DIR", str);
+                //PROC_CMD("/bin/cp", buf2, buf3);
             }
             else
                 continue;

--- a/util/mailpost.c
+++ b/util/mailpost.c
@@ -372,7 +372,7 @@ post_article(void)
         strcpy(hdr.nick, myacct.username);
     mytitle[TTLEN] = '\0';
     strcpy(hdr.title, mytitle);
-    rec_append(fpath, &hdr, sizeof(hdr));
+    rec_bot(fpath, &hdr, sizeof(hdr));
 
     if ((mymode == NET_SAVE) && (fp = fopen("innd/out.bntp", "a")))
     {

--- a/util/restorebrd.c
+++ b/util/restorebrd.c
@@ -14,8 +14,8 @@ reaper(
     const char *lowid)
 {
     char buf[256];
-    sprintf(buf, "tar zxvf /var/tape/brd/%s ", lowid);
-    system(buf);
+    sprintf(buf, "/var/tape/brd/%s", lowid);
+    PROC_CMD("/bin/tar", "zxvf", buf);
 }
 
 static void

--- a/util/restoregem.c
+++ b/util/restoregem.c
@@ -14,8 +14,8 @@ reaper(
     const char *lowid)
 {
     char buf[256];
-    sprintf(buf, "tar zxvf /var/tape/gem/%s ", lowid);
-    system(buf);
+    sprintf(buf, "/var/tape/gem/%s", lowid);
+    PROC_CMD("/bin/tar", "zxvf", buf);
 }
 
 static void

--- a/util/restoreusr.c
+++ b/util/restoreusr.c
@@ -14,9 +14,10 @@ reaper(
     const char *fpath,
     const char *lowid)
 {
-    char buf[256];
-    sprintf(buf, "tar zxvf /var/tape/usr/%c/%s -C \"" BBSHOME "/usr/%c\"", *lowid, lowid, *lowid);
-    system(buf);
+    char buf[256], buf1[256];
+    sprintf(buf, "/var/tape/usr/%c/%s", *lowid, lowid);
+    sprintf(buf1, BBSHOME "/usr/%c", *lowid);
+    PROC_CMD("/bin/tar", "zxvf", buf, "-C", buf1);
 }
 
 static void


### PR DESCRIPTION
Relevant issues: #45

# Fix Pack 005c Change Log (en-US)

## Fixes relevant to user experience
- Now a warning prompt displays when users try to lock their post but do not have the moderator permission to unlock the post.
- Fix exiting from the <kbd>Ctrl</kbd>-<kbd>Z</kbd> menu triggers the welcome screen of the current board.
- Fix idling guests get disconnected abnormally
- Fix the kicker session's pid wrongly logged as the kicked session's pid when the previous session is kicked due to multi-session
- Now a lot of screens automatically redraw when the screen resizes, e.g., `xover()`, `popupmenu()`, `vget()`.
- Add xover command `XO_CUR + pos`. This command redraws the item under the cursor and then relatively moves the cursor, so that the relevant function is simplified and improved

## Fixes relevant to BBS architecture
- Change some commands for main menu to be the same as the commands for xover list. Please re-compile the programs, since the macro values have been changes.
- Unify the special values used by the data structure for the main menu and for the popupmenu. Please re-compile the programs, since the macro values have been changed.
- Deprecate `iac_count()` in favor of the new bound-checking `iac_process()`
- Add new system program–calling functions which is more secure to replace `system()` function calls to improve security

## Other fixes
- Fix `mailpost` ignores bottomed posts
- Fix pmore not correctly handling key `\0` (fixed in PttBBS beforehand)
- Replace some hardcoded paths.
- Other minor fixes. For details, please see the commit log

# Fix Pack 005c Change Log (zh-TW)

## 與使用者體驗有關的修正
- 現在鎖文時，如果沒有板主權限而不能自行解鎖，會先顯示警告訊息要使用者確認
- 修正從 <kbd>Ctrl</kbd>-<kbd>Z</kbd> 選單離開會跳出進板畫面的問題
- 修正訪客閒置時異常斷線
- 修正踢除重複連線時，踢人的 pid 被誤當成被踢的 pid 記錄
- 現在許多畫面在螢幕大小變更時會自動重繪，如 `xover()` 列表、`popupmenu()` 選單、`vget()` 訊息
- 新增 xover 指令 `XO_CUR + pos`，此指令可重繪游標所在的項目再相對移動游標，簡化並改善了相關功能的處理

## 與 BBS 架構有關的修正
- 將主選單的一部分指令改成與 xover 列表所使用的指令相同。Macro 值改了，請重新編譯。
- 統一主選單與彈出式選單的資料結構所用的特殊值。Macro 值改了，請重新編譯。
- 棄用 `iac_count()`，改用新的有邊界檢查的 `iac_process()`
- 新增不須使用 shell 的較安全的系統程式呼叫函式取代部分 `system()` 函式呼叫，改善安全性

## 其它修正
- 修正 `mailpost` 忽略置底文章的問題
- 修正 pmore 不正確處理 `\0` 按鍵的問題（已先在 PttBBS 修正）
- 取代一些寫死的路徑
- 其它小修正，請見 commit 紀錄