### PR TITLE
Fix wrongly generated path for top-users statistic

### DIFF
--- a/scripts/start.sh.in
+++ b/scripts/start.sh.in
@@ -1,5 +1,5 @@
 if [ "${BBSHOME}" = "" ]; then BBSHOME="@BBSHOME@"; fi
 if [ "${BBSVER}" = "" ]; then BBSVER="@BBSVER@"; fi
-"$BBSHOME/bin$BBSVER/camera"
-"$BBSHOME/bin$BBSVER/acpro"
-"$BBSHOME/bin$BBSVER/makefw"
+${BBSHOME}/bin${BBSVER}/camera
+${BBSHOME}/bin${BBSVER}/acpro
+${BBSHOME}/bin${BBSVER}/makefw

--- a/scripts/start.sh.in
+++ b/scripts/start.sh.in
@@ -1,5 +1,5 @@
 if [ "${BBSHOME}" = "" ]; then BBSHOME="@BBSHOME@"; fi
 if [ "${BBSVER}" = "" ]; then BBSVER="@BBSVER@"; fi
-${BBSHOME}/bin${BBSVER}/camera
-${BBSHOME}/bin${BBSVER}/acpro
-${BBSHOME}/bin${BBSVER}/makefw
+"${BBSHOME}"/bin"${BBSVER}"/camera
+"${BBSHOME}"/bin"${BBSVER}"/acpro
+"${BBSHOME}"/bin"${BBSVER}"/makefw

--- a/scripts/top.sh.in
+++ b/scripts/top.sh.in
@@ -2,5 +2,5 @@
 # 排行榜程式執行
 if [ "${BBSHOME}" = "" ]; then BBSHOME="@BBSHOME@"; fi
 if [ "${BBSVER}" = "" ]; then BBSVER="@BBSVER@"; fi
-${BBSHOME}/bin${BBSVER}/topusr > ${BBSHOME}/gem/\@/\@pop.new
-mv ${BBSHOME}/gem/\@/\@pop.new ${BBSHOME}/gem/\@/\@pop
+"${BBSHOME}"/bin"${BBSVER}"/topusr > "${BBSHOME}"/gem/\@/\@pop.new
+mv "${BBSHOME}"/gem/\@/\@pop.new "${BBSHOME}"/gem/\@/\@pop

--- a/scripts/top.sh.in
+++ b/scripts/top.sh.in
@@ -2,5 +2,5 @@
 # 排行榜程式執行
 if [ "${BBSHOME}" = "" ]; then BBSHOME="@BBSHOME@"; fi
 if [ "${BBSVER}" = "" ]; then BBSVER="@BBSVER@"; fi
-"${BBSHOME}/bin${BBSVER}/topusr" > "${BBSHOME}/gem/@/@pop.new"
-mv "${BBSHOME}/gem/@/@pop.new" "${BBSHOME}/gem/@/@pop"
+${BBSHOME}/bin${BBSVER}/topusr > ${BBSHOME}/gem/\@/\@pop.new
+mv ${BBSHOME}/gem/\@/\@pop.new ${BBSHOME}/gem/\@/\@pop


### PR DESCRIPTION
@ symbols in gem path should not be replaced by cmake `@var@` mechanism, in this case, `"${BBSHOME}/gem/@/@pop"` is wrongly changed to `${BBSHOME}/gem/pop` 
Also change shell variable format in `start.sh`